### PR TITLE
fix: prevent code editor refresh overwriting changes

### DIFF
--- a/clients/playground/src/components/ui/code-editor.tsx
+++ b/clients/playground/src/components/ui/code-editor.tsx
@@ -73,7 +73,7 @@ export const CodeEditor = (props: CodeEditorProps) => {
   // File-based content handling
   const { content: opfsContent } = useFileContent(usingFilePath ? filePath! : "");
   const [editorContent, setEditorContent] = useState<string>("");
-  const editorContentRef = useRef('');
+  const editorContentRef = useRef("");
   const lastFilePathRef = useRef<string | undefined>(undefined);
   const lastSyncedContentRef = useRef<string>("");
   const isDirtyRef = useRef(false);
@@ -100,7 +100,6 @@ export const CodeEditor = (props: CodeEditorProps) => {
       lastSyncedContentRef.current = "";
       isDirtyRef.current = false;
       setEditorContent("");
-      editorContentRef.current = "";
       return;
     }
 
@@ -111,7 +110,6 @@ export const CodeEditor = (props: CodeEditorProps) => {
       lastSyncedContentRef.current = nextContent;
       isDirtyRef.current = false;
       setEditorContent(nextContent);
-      editorContentRef.current = nextContent;
       return;
     }
 
@@ -157,7 +155,7 @@ export const CodeEditor = (props: CodeEditorProps) => {
         if (pendingSaveRef.current) {
           const next = pendingSaveRef.current;
           pendingSaveRef.current = null;
-          void runSave(next.path, next.content);
+          runSave(next.path, next.content);
         }
       }
     };
@@ -168,7 +166,7 @@ export const CodeEditor = (props: CodeEditorProps) => {
         return;
       }
 
-      void runSave(path, content);
+      runSave(path, content);
     }, 500);
   };
 

--- a/clients/playground/src/components/ui/code-editor.tsx
+++ b/clients/playground/src/components/ui/code-editor.tsx
@@ -73,7 +73,7 @@ export const CodeEditor = (props: CodeEditorProps) => {
   // File-based content handling
   const { content: opfsContent } = useFileContent(usingFilePath ? filePath! : "");
   const [editorContent, setEditorContent] = useState<string>("");
-  const editorContentRef = useRef(editorContent);
+  const editorContentRef = useRef('');
   const lastFilePathRef = useRef<string | undefined>(undefined);
   const lastSyncedContentRef = useRef<string>("");
   const isDirtyRef = useRef(false);


### PR DESCRIPTION
## Summary
- keep the Monaco editor content in sync with the selected file without clobbering in-progress edits
- track dirty state and last-synced content to ensure OPFS updates only apply when safe
- queue auto-save writes so the latest change is persisted once prior saves finish

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test` *(fails: repository requires Node 22 for Array.fromAsync while the environment provides Node 20)*

------
https://chatgpt.com/codex/tasks/task_e_68c884bbde1083218430adb9f8deaff6