### PR TITLE
Fix tool group key stability in conversation message list

### DIFF
--- a/clients/playground/src/components/conversation/ConversationArea/MessageList.tsx
+++ b/clients/playground/src/components/conversation/ConversationArea/MessageList.tsx
@@ -108,11 +108,10 @@ function useRenderPlan(messages: Message[]): RenderItem[] {
           j += 1;
         }
 
-        const lastId = messages[j - 1].id;
         const completed = j < messages.length; // another message follows the group
         items.push({
           kind: "tool-group",
-          key: `tool-group-${startId}-${lastId}`,
+          key: `tool-group-${startId}`,
           invocations,
           completed,
         });


### PR DESCRIPTION
## Summary
- keep `CollapsibleToolTimeline` mounted when streaming by stabilizing the tool group render key

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test` *(fails: `Array.fromAsync` is not a function when running under Node v20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c9048379ec83218baad7ecd476a17d