### PR TITLE
refactor(todo): add zustand state provider

### DIFF
--- a/clients/playground/src/App.tsx
+++ b/clients/playground/src/App.tsx
@@ -11,6 +11,7 @@ import { GithubCorner } from "./components/ui/github-corner";
 import { TopBar } from "./components/ui/top-bar";
 import { PROJECTS_ROOT } from "./constant";
 import { TodoList } from "./examples/todo/component";
+import { TodoProvider } from "./examples/todo/state/TodoProvider";
 import { useDragAndDropUpload } from "./services/drag-n-drop";
 import { setupExample } from "./services/playground/setup";
 import { useWorkspaceStore } from "./state/WorkspaceProvider";
@@ -133,7 +134,9 @@ export function App() {
                 <Tabs.Content value="preview" flex="1" display="flex" overflow="hidden" padding="0">
                   <Box flex="1" overflow="hidden">
                     {selectedProject === "todo" ? (
-                      <TodoList />
+                      <TodoProvider>
+                        <TodoList />
+                      </TodoProvider>
                     ) : (
                       <Flex align="center" justify="center" height="100%">
                         <Text color="fg.secondary">Slides — coming soon</Text>

--- a/clients/playground/src/examples/todo/state/TodoProvider.tsx
+++ b/clients/playground/src/examples/todo/state/TodoProvider.tsx
@@ -1,0 +1,79 @@
+import { createContext, useEffect, useRef } from "react";
+import type { StoreApi, UseBoundStore } from "zustand";
+import { watchDirectory } from "@pstdio/opfs-utils";
+import { createTodoStore, TODO_LISTS_DIR } from "./createStore";
+import type { TodoStore } from "./types";
+
+export const TodoContext = createContext<UseBoundStore<StoreApi<TodoStore>> | null>(null);
+
+export let useTodoStore: UseBoundStore<StoreApi<TodoStore>>;
+
+export function TodoProvider({ children }: React.PropsWithChildren) {
+  const storeRef = useRef<UseBoundStore<StoreApi<TodoStore>> | null>(null);
+
+  if (!storeRef.current) {
+    useTodoStore = createTodoStore();
+    storeRef.current = useTodoStore;
+  }
+
+  useEffect(() => {
+    if (!storeRef.current) return;
+
+    const store = storeRef.current;
+
+    let cleanup: null | (() => void) = null;
+    let cancelled = false;
+    const controller = new AbortController();
+
+    void (async () => {
+      try {
+        await store.getState().initialize();
+
+        cleanup = await watchDirectory(
+          TODO_LISTS_DIR,
+          (changes) => {
+            if (cancelled) return;
+
+            const { selectedList } = store.getState();
+            let needsListRefresh = false;
+            let needsItemRefresh = false;
+
+            for (const change of changes) {
+              const relativePath = change.path.join("/");
+              if (change.type === "appeared" || change.type === "disappeared") {
+                needsListRefresh = true;
+              }
+
+              if (
+                selectedList &&
+                relativePath === selectedList &&
+                (change.type === "modified" || change.type === "appeared")
+              ) {
+                needsItemRefresh = true;
+              }
+            }
+
+            if (needsListRefresh) {
+              void store.getState().refreshLists();
+            }
+
+            if (needsItemRefresh && selectedList) {
+              void store.getState().readAndParse(selectedList);
+            }
+          },
+          { recursive: false, emitInitial: false, signal: controller.signal },
+        );
+      } catch (error) {
+        console.warn("Todo watcher error", error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      cleanup?.();
+    };
+  }, []);
+
+  return <TodoContext.Provider value={storeRef.current}>{children}</TodoContext.Provider>;
+}

--- a/clients/playground/src/examples/todo/state/createStore.ts
+++ b/clients/playground/src/examples/todo/state/createStore.ts
@@ -1,0 +1,240 @@
+import { PROJECTS_ROOT } from "@/constant";
+import { deleteFile, ensureDirExists, ls, readFile, writeFile } from "@pstdio/opfs-utils";
+import { create } from "zustand";
+import type { TodoItem, TodoStore } from "./types";
+
+export const TODO_LISTS_DIR = `${PROJECTS_ROOT}/todo/todos`;
+
+function parseMarkdownTodos(md: string): TodoItem[] {
+  const lines = md.split("\n");
+
+  const items: TodoItem[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const match = /^\s*[-*]\s*\[( |x|X)\]\s*(.*)$/.exec(line);
+    if (!match) continue;
+
+    const done = match[1].toLowerCase() === "x";
+    const text = match[2] ?? "";
+
+    items.push({ line: i, text, done });
+  }
+
+  return items;
+}
+
+function toggleCheckboxAtLine(md: string, lineIndex: number, checked: boolean): string {
+  const lines = md.split("\n");
+  const line = lines[lineIndex] ?? "";
+
+  const toggled = line.replace(/(\s*[-*]\s*\[)( |x|X)(\]\s*)/, (_match, prefix, _current, suffix) => {
+    const next = checked ? "x" : " ";
+    return `${prefix}${next}${suffix}`;
+  });
+
+  lines[lineIndex] = toggled;
+  return lines.join("\n");
+}
+
+function replaceTodoTextAtLine(md: string, lineIndex: number, nextText: string): string {
+  const lines = md.split("\n");
+  const line = lines[lineIndex] ?? "";
+
+  const replaced = line.replace(/^(\s*[-*]\s*\[(?: |x|X)\]\s*)(.*)$/u, (_match, prefix) => `${prefix}${nextText}`);
+
+  lines[lineIndex] = replaced;
+  return lines.join("\n");
+}
+
+export const createTodoStore = () =>
+  create<TodoStore>()((set, get) => ({
+    error: null,
+    lists: [],
+    selectedList: null,
+    content: null,
+    items: [],
+    newListName: "",
+    newItemText: "",
+    editingLine: null,
+    editingText: "",
+    deleteModalOpen: false,
+    pendingDeleteList: null,
+    setNewListName: (value: string) => set({ newListName: value }),
+    setNewItemText: (value: string) => set({ newItemText: value }),
+    setEditingText: (value: string) => set({ editingText: value }),
+    setError: (message: string | null) => set({ error: message }),
+    refreshLists: async () => {
+      const previousSelected = get().selectedList;
+      try {
+        set({ error: null });
+        await ensureDirExists(TODO_LISTS_DIR, true);
+        const entries = await ls(TODO_LISTS_DIR, { maxDepth: 1, kinds: ["file"], include: ["*.md"] });
+        const names = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+        const nextSelected = names.includes(previousSelected ?? "") ? previousSelected : (names[0] ?? null);
+
+        set({
+          lists: names,
+          selectedList: nextSelected,
+          ...(nextSelected ? {} : { content: null, items: [] }),
+        });
+
+        if (nextSelected) {
+          await get().readAndParse(nextSelected);
+        }
+      } catch (error) {
+        set({ error: error instanceof Error ? error.message : String(error) });
+      }
+    },
+    readAndParse: async (fileName: string) => {
+      const path = `${TODO_LISTS_DIR}/${fileName}`;
+      try {
+        const md = await readFile(path);
+        set({
+          content: md,
+          items: parseMarkdownTodos(md),
+          error: null,
+        });
+      } catch (error: any) {
+        if (error?.name === "NotFoundError") {
+          set({ error: `File not found: ${path}` });
+        } else {
+          set({ error: error instanceof Error ? error.message : String(error) });
+        }
+      }
+    },
+    selectList: async (name: string) => {
+      set({ selectedList: name });
+      await get().readAndParse(name);
+    },
+    addList: async () => {
+      const { newListName } = get();
+      const raw = (newListName || "New List").trim();
+      if (!raw) return;
+
+      const name = raw.toLowerCase().endsWith(".md") ? raw : `${raw}.md`;
+      const path = `${TODO_LISTS_DIR}/${name}`;
+
+      try {
+        await writeFile(path, "- [ ] New item\n");
+        set({ newListName: "" });
+        await get().refreshLists();
+        await get().selectList(name);
+      } catch (error) {
+        set({ error: error instanceof Error ? error.message : String(error) });
+      }
+    },
+    removeList: async (name: string) => {
+      const path = `${TODO_LISTS_DIR}/${name}`;
+      try {
+        await deleteFile(path);
+        if (get().selectedList === name) {
+          set({ selectedList: null, content: null, items: [] });
+        }
+        await get().refreshLists();
+      } catch (error) {
+        set({ error: error instanceof Error ? error.message : String(error) });
+      }
+    },
+    requestDeleteList: (name: string) => set({ pendingDeleteList: name, deleteModalOpen: true }),
+    cancelDeleteList: () => set({ deleteModalOpen: false, pendingDeleteList: null }),
+    confirmDeleteList: async () => {
+      const { pendingDeleteList } = get();
+      if (!pendingDeleteList) return;
+
+      await get().removeList(pendingDeleteList);
+      set({ pendingDeleteList: null, deleteModalOpen: false });
+    },
+    setChecked: async (line: number, checked: boolean) => {
+      const { selectedList, content } = get();
+      if (!selectedList || content == null) return;
+
+      const previous = content;
+      const next = toggleCheckboxAtLine(content, line, checked);
+
+      set({ content: next, items: parseMarkdownTodos(next) });
+
+      try {
+        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+      } catch (error) {
+        set({
+          content: previous,
+          items: parseMarkdownTodos(previous),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    addItem: async () => {
+      const { selectedList, content, newItemText } = get();
+      if (!selectedList) return;
+
+      const text = newItemText.trim();
+      if (!text) return;
+
+      const previous = content ?? "";
+      const prefix = previous.endsWith("\n") || previous.length === 0 ? "" : "\n";
+      const next = previous + prefix + `- [ ] ${text}\n`;
+
+      set({ content: next, items: parseMarkdownTodos(next), newItemText: "" });
+
+      try {
+        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+      } catch (error) {
+        set({
+          content: previous,
+          items: parseMarkdownTodos(previous),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    removeItem: async (line: number) => {
+      const { selectedList, content } = get();
+      if (!selectedList || content == null) return;
+
+      const lines = content.split("\n");
+      if (line < 0 || line >= lines.length) return;
+
+      const previous = content;
+      lines.splice(line, 1);
+      const next = lines.join("\n");
+
+      set({ content: next, items: parseMarkdownTodos(next) });
+
+      try {
+        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+      } catch (error) {
+        set({
+          content: previous,
+          items: parseMarkdownTodos(previous),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    startEditing: (line: number, currentText: string) => set({ editingLine: line, editingText: currentText }),
+    cancelEditing: () => set({ editingLine: null, editingText: "" }),
+    saveEditing: async () => {
+      const { editingLine, selectedList, content, editingText } = get();
+      if (editingLine == null || !selectedList || content == null) return;
+
+      const next = replaceTodoTextAtLine(content, editingLine, editingText.trim());
+
+      set({ content: next, items: parseMarkdownTodos(next), editingLine: null, editingText: "" });
+
+      try {
+        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+      } catch (error) {
+        set({
+          content,
+          items: parseMarkdownTodos(content),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    initialize: async () => {
+      try {
+        await get().refreshLists();
+      } catch (error) {
+        set({ error: error instanceof Error ? error.message : String(error) });
+      }
+    },
+  }));

--- a/clients/playground/src/examples/todo/state/createStore.ts
+++ b/clients/playground/src/examples/todo/state/createStore.ts
@@ -1,6 +1,8 @@
 import { PROJECTS_ROOT } from "@/constant";
 import { deleteFile, ensureDirExists, ls, readFile, writeFile } from "@pstdio/opfs-utils";
 import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
 import type { TodoItem, TodoStore } from "./types";
 
 export const TODO_LISTS_DIR = `${PROJECTS_ROOT}/todo/todos`;
@@ -48,193 +50,198 @@ function replaceTodoTextAtLine(md: string, lineIndex: number, nextText: string):
 }
 
 export const createTodoStore = () =>
-  create<TodoStore>()((set, get) => ({
-    error: null,
-    lists: [],
-    selectedList: null,
-    content: null,
-    items: [],
-    newListName: "",
-    newItemText: "",
-    editingLine: null,
-    editingText: "",
-    deleteModalOpen: false,
-    pendingDeleteList: null,
-    setNewListName: (value: string) => set({ newListName: value }),
-    setNewItemText: (value: string) => set({ newItemText: value }),
-    setEditingText: (value: string) => set({ editingText: value }),
-    setError: (message: string | null) => set({ error: message }),
-    refreshLists: async () => {
-      const previousSelected = get().selectedList;
-      try {
-        set({ error: null });
-        await ensureDirExists(TODO_LISTS_DIR, true);
-        const entries = await ls(TODO_LISTS_DIR, { maxDepth: 1, kinds: ["file"], include: ["*.md"] });
-        const names = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
-        const nextSelected = names.includes(previousSelected ?? "") ? previousSelected : (names[0] ?? null);
+  create<TodoStore>()(
+    devtools(
+      immer<TodoStore>((set, get) => ({
+        error: null,
+        lists: [],
+        selectedList: null,
+        content: null,
+        items: [],
+        newListName: "",
+        newItemText: "",
+        editingLine: null,
+        editingText: "",
+        deleteModalOpen: false,
+        pendingDeleteList: null,
+        setNewListName: (value: string) => set({ newListName: value }),
+        setNewItemText: (value: string) => set({ newItemText: value }),
+        setEditingText: (value: string) => set({ editingText: value }),
+        setError: (message: string | null) => set({ error: message }),
+        refreshLists: async () => {
+          const previousSelected = get().selectedList;
+          try {
+            set({ error: null });
+            await ensureDirExists(TODO_LISTS_DIR, true);
+            const entries = await ls(TODO_LISTS_DIR, { maxDepth: 1, kinds: ["file"], include: ["*.md"] });
+            const names = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+            const nextSelected = names.includes(previousSelected ?? "") ? previousSelected : (names[0] ?? null);
 
-        set({
-          lists: names,
-          selectedList: nextSelected,
-          ...(nextSelected ? {} : { content: null, items: [] }),
-        });
+            set({
+              lists: names,
+              selectedList: nextSelected,
+              ...(nextSelected ? {} : { content: null, items: [] }),
+            });
 
-        if (nextSelected) {
-          await get().readAndParse(nextSelected);
-        }
-      } catch (error) {
-        set({ error: error instanceof Error ? error.message : String(error) });
-      }
-    },
-    readAndParse: async (fileName: string) => {
-      const path = `${TODO_LISTS_DIR}/${fileName}`;
-      try {
-        const md = await readFile(path);
-        set({
-          content: md,
-          items: parseMarkdownTodos(md),
-          error: null,
-        });
-      } catch (error: any) {
-        if (error?.name === "NotFoundError") {
-          set({ error: `File not found: ${path}` });
-        } else {
-          set({ error: error instanceof Error ? error.message : String(error) });
-        }
-      }
-    },
-    selectList: async (name: string) => {
-      set({ selectedList: name });
-      await get().readAndParse(name);
-    },
-    addList: async () => {
-      const { newListName } = get();
-      const raw = (newListName || "New List").trim();
-      if (!raw) return;
+            if (nextSelected) {
+              await get().readAndParse(nextSelected);
+            }
+          } catch (error) {
+            set({ error: error instanceof Error ? error.message : String(error) });
+          }
+        },
+        readAndParse: async (fileName: string) => {
+          const path = `${TODO_LISTS_DIR}/${fileName}`;
+          try {
+            const md = await readFile(path);
+            set({
+              content: md,
+              items: parseMarkdownTodos(md),
+              error: null,
+            });
+          } catch (error: any) {
+            if (error?.name === "NotFoundError") {
+              set({ error: `File not found: ${path}` });
+            } else {
+              set({ error: error instanceof Error ? error.message : String(error) });
+            }
+          }
+        },
+        selectList: async (name: string) => {
+          set({ selectedList: name });
+          await get().readAndParse(name);
+        },
+        addList: async () => {
+          const { newListName } = get();
+          const raw = (newListName || "New List").trim();
+          if (!raw) return;
 
-      const name = raw.toLowerCase().endsWith(".md") ? raw : `${raw}.md`;
-      const path = `${TODO_LISTS_DIR}/${name}`;
+          const name = raw.toLowerCase().endsWith(".md") ? raw : `${raw}.md`;
+          const path = `${TODO_LISTS_DIR}/${name}`;
 
-      try {
-        await writeFile(path, "- [ ] New item\n");
-        set({ newListName: "" });
-        await get().refreshLists();
-        await get().selectList(name);
-      } catch (error) {
-        set({ error: error instanceof Error ? error.message : String(error) });
-      }
-    },
-    removeList: async (name: string) => {
-      const path = `${TODO_LISTS_DIR}/${name}`;
-      try {
-        await deleteFile(path);
-        if (get().selectedList === name) {
-          set({ selectedList: null, content: null, items: [] });
-        }
-        await get().refreshLists();
-      } catch (error) {
-        set({ error: error instanceof Error ? error.message : String(error) });
-      }
-    },
-    requestDeleteList: (name: string) => set({ pendingDeleteList: name, deleteModalOpen: true }),
-    cancelDeleteList: () => set({ deleteModalOpen: false, pendingDeleteList: null }),
-    confirmDeleteList: async () => {
-      const { pendingDeleteList } = get();
-      if (!pendingDeleteList) return;
+          try {
+            await writeFile(path, "- [ ] New item\n");
+            set({ newListName: "" });
+            await get().refreshLists();
+            await get().selectList(name);
+          } catch (error) {
+            set({ error: error instanceof Error ? error.message : String(error) });
+          }
+        },
+        removeList: async (name: string) => {
+          const path = `${TODO_LISTS_DIR}/${name}`;
+          try {
+            await deleteFile(path);
+            if (get().selectedList === name) {
+              set({ selectedList: null, content: null, items: [] });
+            }
+            await get().refreshLists();
+          } catch (error) {
+            set({ error: error instanceof Error ? error.message : String(error) });
+          }
+        },
+        requestDeleteList: (name: string) => set({ pendingDeleteList: name, deleteModalOpen: true }),
+        cancelDeleteList: () => set({ deleteModalOpen: false, pendingDeleteList: null }),
+        confirmDeleteList: async () => {
+          const { pendingDeleteList } = get();
+          if (!pendingDeleteList) return;
 
-      await get().removeList(pendingDeleteList);
-      set({ pendingDeleteList: null, deleteModalOpen: false });
-    },
-    setChecked: async (line: number, checked: boolean) => {
-      const { selectedList, content } = get();
-      if (!selectedList || content == null) return;
+          await get().removeList(pendingDeleteList);
+          set({ pendingDeleteList: null, deleteModalOpen: false });
+        },
+        setChecked: async (line: number, checked: boolean) => {
+          const { selectedList, content } = get();
+          if (!selectedList || content == null) return;
 
-      const previous = content;
-      const next = toggleCheckboxAtLine(content, line, checked);
+          const previous = content;
+          const next = toggleCheckboxAtLine(content, line, checked);
 
-      set({ content: next, items: parseMarkdownTodos(next) });
+          set({ content: next, items: parseMarkdownTodos(next) });
 
-      try {
-        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-      } catch (error) {
-        set({
-          content: previous,
-          items: parseMarkdownTodos(previous),
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    },
-    addItem: async () => {
-      const { selectedList, content, newItemText } = get();
-      if (!selectedList) return;
+          try {
+            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+          } catch (error) {
+            set({
+              content: previous,
+              items: parseMarkdownTodos(previous),
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        },
+        addItem: async () => {
+          const { selectedList, content, newItemText } = get();
+          if (!selectedList) return;
 
-      const text = newItemText.trim();
-      if (!text) return;
+          const text = newItemText.trim();
+          if (!text) return;
 
-      const previous = content ?? "";
-      const prefix = previous.endsWith("\n") || previous.length === 0 ? "" : "\n";
-      const next = previous + prefix + `- [ ] ${text}\n`;
+          const previous = content ?? "";
+          const prefix = previous.endsWith("\n") || previous.length === 0 ? "" : "\n";
+          const next = previous + prefix + `- [ ] ${text}\n`;
 
-      set({ content: next, items: parseMarkdownTodos(next), newItemText: "" });
+          set({ content: next, items: parseMarkdownTodos(next), newItemText: "" });
 
-      try {
-        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-      } catch (error) {
-        set({
-          content: previous,
-          items: parseMarkdownTodos(previous),
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    },
-    removeItem: async (line: number) => {
-      const { selectedList, content } = get();
-      if (!selectedList || content == null) return;
+          try {
+            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+          } catch (error) {
+            set({
+              content: previous,
+              items: parseMarkdownTodos(previous),
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        },
+        removeItem: async (line: number) => {
+          const { selectedList, content } = get();
+          if (!selectedList || content == null) return;
 
-      const lines = content.split("\n");
-      if (line < 0 || line >= lines.length) return;
+          const lines = content.split("\n");
+          if (line < 0 || line >= lines.length) return;
 
-      const previous = content;
-      lines.splice(line, 1);
-      const next = lines.join("\n");
+          const previous = content;
+          lines.splice(line, 1);
+          const next = lines.join("\n");
 
-      set({ content: next, items: parseMarkdownTodos(next) });
+          set({ content: next, items: parseMarkdownTodos(next) });
 
-      try {
-        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-      } catch (error) {
-        set({
-          content: previous,
-          items: parseMarkdownTodos(previous),
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    },
-    startEditing: (line: number, currentText: string) => set({ editingLine: line, editingText: currentText }),
-    cancelEditing: () => set({ editingLine: null, editingText: "" }),
-    saveEditing: async () => {
-      const { editingLine, selectedList, content, editingText } = get();
-      if (editingLine == null || !selectedList || content == null) return;
+          try {
+            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+          } catch (error) {
+            set({
+              content: previous,
+              items: parseMarkdownTodos(previous),
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        },
+        startEditing: (line: number, currentText: string) => set({ editingLine: line, editingText: currentText }),
+        cancelEditing: () => set({ editingLine: null, editingText: "" }),
+        saveEditing: async () => {
+          const { editingLine, selectedList, content, editingText } = get();
+          if (editingLine == null || !selectedList || content == null) return;
 
-      const next = replaceTodoTextAtLine(content, editingLine, editingText.trim());
+          const next = replaceTodoTextAtLine(content, editingLine, editingText.trim());
 
-      set({ content: next, items: parseMarkdownTodos(next), editingLine: null, editingText: "" });
+          set({ content: next, items: parseMarkdownTodos(next), editingLine: null, editingText: "" });
 
-      try {
-        await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-      } catch (error) {
-        set({
-          content,
-          items: parseMarkdownTodos(content),
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    },
-    initialize: async () => {
-      try {
-        await get().refreshLists();
-      } catch (error) {
-        set({ error: error instanceof Error ? error.message : String(error) });
-      }
-    },
-  }));
+          try {
+            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+          } catch (error) {
+            set({
+              content,
+              items: parseMarkdownTodos(content),
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        },
+        initialize: async () => {
+          try {
+            await get().refreshLists();
+          } catch (error) {
+            set({ error: error instanceof Error ? error.message : String(error) });
+          }
+        },
+      })),
+      { name: "TodoStore" },
+    ),
+  );

--- a/clients/playground/src/examples/todo/state/types.ts
+++ b/clients/playground/src/examples/todo/state/types.ts
@@ -1,0 +1,38 @@
+export interface TodoItem {
+  line: number;
+  text: string;
+  done: boolean;
+}
+
+export interface TodoStore {
+  error: string | null;
+  lists: string[];
+  selectedList: string | null;
+  content: string | null;
+  items: TodoItem[];
+  newListName: string;
+  newItemText: string;
+  editingLine: number | null;
+  editingText: string;
+  deleteModalOpen: boolean;
+  pendingDeleteList: string | null;
+  setNewListName: (value: string) => void;
+  setNewItemText: (value: string) => void;
+  setEditingText: (value: string) => void;
+  refreshLists: () => Promise<void>;
+  readAndParse: (fileName: string) => Promise<void>;
+  selectList: (name: string) => Promise<void>;
+  addList: () => Promise<void>;
+  removeList: (name: string) => Promise<void>;
+  requestDeleteList: (name: string) => void;
+  cancelDeleteList: () => void;
+  confirmDeleteList: () => Promise<void>;
+  setChecked: (line: number, checked: boolean) => Promise<void>;
+  addItem: () => Promise<void>;
+  removeItem: (line: number) => Promise<void>;
+  startEditing: (line: number, currentText: string) => void;
+  cancelEditing: () => void;
+  saveEditing: () => Promise<void>;
+  initialize: () => Promise<void>;
+  setError: (message: string | null) => void;
+}


### PR DESCRIPTION
## Summary
- add a dedicated Zustand store and provider for the todo example
- migrate todo component state to the shared store and wrap the preview with the provider

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test` *(fails: "+ Array.fromAsync is not a function" in opfs-utils suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c90460bd3c832191e21abca352771a