### PR TITLE
feat(playground): persist todo state to opfs

### DIFF
--- a/clients/playground/src/examples/todo/state/createStore.ts
+++ b/clients/playground/src/examples/todo/state/createStore.ts
@@ -1,4 +1,5 @@
 import { PROJECTS_ROOT } from "@/constant";
+import { persistToOpfs } from "@/services/state/opfsPersist";
 import { deleteFile, ensureDirExists, ls, readFile, writeFile } from "@pstdio/opfs-utils";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
@@ -6,6 +7,39 @@ import { immer } from "zustand/middleware/immer";
 import type { TodoItem, TodoStore } from "./types";
 
 export const TODO_LISTS_DIR = `${PROJECTS_ROOT}/todo/todos`;
+const TODO_STORE_PERSIST_KEY = "kaset-todo-store";
+const TODO_STORE_PERSIST_VERSION = 1;
+const DEFAULT_PERSIST_FILE = `${PROJECTS_ROOT}/todo/.state/todo-store.json`;
+
+type TodoStorePersistedState = Partial<
+  Pick<
+    TodoStore,
+    | "selectedList"
+    | "newListName"
+    | "newItemText"
+    | "editingLine"
+    | "editingText"
+    | "deleteModalOpen"
+    | "pendingDeleteList"
+  >
+>;
+
+const defaultPartialize = (state: TodoStore): TodoStorePersistedState => ({
+  selectedList: state.selectedList,
+  newListName: state.newListName,
+  newItemText: state.newItemText,
+  editingLine: state.editingLine,
+  editingText: state.editingText,
+  deleteModalOpen: state.deleteModalOpen,
+  pendingDeleteList: state.pendingDeleteList,
+});
+
+export interface TodoStoreOptions {
+  /** Override the OPFS path used for persisting todo UI state. */
+  persistFilePath?: string;
+  /** Customize which pieces of the todo store state are persisted. */
+  persistPartialize?: (state: TodoStore) => Partial<TodoStore>;
+}
 
 function parseMarkdownTodos(md: string): TodoItem[] {
   const lines = md.split("\n");
@@ -49,199 +83,215 @@ function replaceTodoTextAtLine(md: string, lineIndex: number, nextText: string):
   return lines.join("\n");
 }
 
-export const createTodoStore = () =>
-  create<TodoStore>()(
-    devtools(
-      immer<TodoStore>((set, get) => ({
-        error: null,
-        lists: [],
-        selectedList: null,
-        content: null,
-        items: [],
-        newListName: "",
-        newItemText: "",
-        editingLine: null,
-        editingText: "",
-        deleteModalOpen: false,
-        pendingDeleteList: null,
-        setNewListName: (value: string) => set({ newListName: value }),
-        setNewItemText: (value: string) => set({ newItemText: value }),
-        setEditingText: (value: string) => set({ editingText: value }),
-        setError: (message: string | null) => set({ error: message }),
-        refreshLists: async () => {
-          const previousSelected = get().selectedList;
-          try {
-            set({ error: null });
-            await ensureDirExists(TODO_LISTS_DIR, true);
-            const entries = await ls(TODO_LISTS_DIR, { maxDepth: 1, kinds: ["file"], include: ["*.md"] });
-            const names = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
-            const nextSelected = names.includes(previousSelected ?? "") ? previousSelected : (names[0] ?? null);
+export const createTodoStore = (options: TodoStoreOptions = {}) => {
+  const persistFilePath = options.persistFilePath ?? DEFAULT_PERSIST_FILE;
+  const partialize = options.persistPartialize ?? defaultPartialize;
 
-            set({
-              lists: names,
-              selectedList: nextSelected,
-              ...(nextSelected ? {} : { content: null, items: [] }),
-            });
+  return create<TodoStore>()(
+    persistToOpfs(
+      devtools(
+        immer<TodoStore>((set, get) => ({
+          error: null,
+          lists: [],
+          selectedList: null,
+          content: null,
+          items: [],
+          newListName: "",
+          newItemText: "",
+          editingLine: null,
+          editingText: "",
+          deleteModalOpen: false,
+          pendingDeleteList: null,
+          setNewListName: (value: string) => set({ newListName: value }),
+          setNewItemText: (value: string) => set({ newItemText: value }),
+          setEditingText: (value: string) => set({ editingText: value }),
+          refreshLists: async () => {
+            const previousSelected = get().selectedList;
+            try {
+              set({ error: null });
+              await ensureDirExists(TODO_LISTS_DIR, true);
+              const entries = await ls(TODO_LISTS_DIR, { maxDepth: 1, kinds: ["file"], include: ["*.md"] });
+              const names = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+              const nextSelected = names.includes(previousSelected ?? "") ? previousSelected : (names[0] ?? null);
 
-            if (nextSelected) {
-              await get().readAndParse(nextSelected);
-            }
-          } catch (error) {
-            set({ error: error instanceof Error ? error.message : String(error) });
-          }
-        },
-        readAndParse: async (fileName: string) => {
-          const path = `${TODO_LISTS_DIR}/${fileName}`;
-          try {
-            const md = await readFile(path);
-            set({
-              content: md,
-              items: parseMarkdownTodos(md),
-              error: null,
-            });
-          } catch (error: any) {
-            if (error?.name === "NotFoundError") {
-              set({ error: `File not found: ${path}` });
-            } else {
+              set({
+                lists: names,
+                selectedList: nextSelected,
+                ...(nextSelected ? {} : { content: null, items: [] }),
+              });
+
+              if (nextSelected) {
+                await get().readAndParse(nextSelected);
+              }
+            } catch (error) {
               set({ error: error instanceof Error ? error.message : String(error) });
             }
-          }
-        },
-        selectList: async (name: string) => {
-          set({ selectedList: name });
-          await get().readAndParse(name);
-        },
-        addList: async () => {
-          const { newListName } = get();
-          const raw = (newListName || "New List").trim();
-          if (!raw) return;
-
-          const name = raw.toLowerCase().endsWith(".md") ? raw : `${raw}.md`;
-          const path = `${TODO_LISTS_DIR}/${name}`;
-
-          try {
-            await writeFile(path, "- [ ] New item\n");
-            set({ newListName: "" });
-            await get().refreshLists();
-            await get().selectList(name);
-          } catch (error) {
-            set({ error: error instanceof Error ? error.message : String(error) });
-          }
-        },
-        removeList: async (name: string) => {
-          const path = `${TODO_LISTS_DIR}/${name}`;
-          try {
-            await deleteFile(path);
-            if (get().selectedList === name) {
-              set({ selectedList: null, content: null, items: [] });
+          },
+          readAndParse: async (fileName: string) => {
+            const path = `${TODO_LISTS_DIR}/${fileName}`;
+            try {
+              const md = await readFile(path);
+              set({
+                content: md,
+                items: parseMarkdownTodos(md),
+                error: null,
+              });
+            } catch (error: any) {
+              if (error?.name === "NotFoundError") {
+                set({ error: `File not found: ${path}` });
+              } else {
+                set({ error: error instanceof Error ? error.message : String(error) });
+              }
             }
-            await get().refreshLists();
-          } catch (error) {
-            set({ error: error instanceof Error ? error.message : String(error) });
-          }
-        },
-        requestDeleteList: (name: string) => set({ pendingDeleteList: name, deleteModalOpen: true }),
-        cancelDeleteList: () => set({ deleteModalOpen: false, pendingDeleteList: null }),
-        confirmDeleteList: async () => {
-          const { pendingDeleteList } = get();
-          if (!pendingDeleteList) return;
+          },
+          selectList: async (name: string) => {
+            set({ selectedList: name });
+            await get().readAndParse(name);
+          },
+          addList: async () => {
+            const { newListName } = get();
+            const raw = (newListName || "New List").trim();
+            if (!raw) return;
 
-          await get().removeList(pendingDeleteList);
-          set({ pendingDeleteList: null, deleteModalOpen: false });
-        },
-        setChecked: async (line: number, checked: boolean) => {
-          const { selectedList, content } = get();
-          if (!selectedList || content == null) return;
+            const name = raw.toLowerCase().endsWith(".md") ? raw : `${raw}.md`;
+            const path = `${TODO_LISTS_DIR}/${name}`;
 
-          const previous = content;
-          const next = toggleCheckboxAtLine(content, line, checked);
+            try {
+              await writeFile(path, "- [ ] New item\n");
+              set({ newListName: "" });
+              await get().refreshLists();
+              await get().selectList(name);
+            } catch (error) {
+              set({ error: error instanceof Error ? error.message : String(error) });
+            }
+          },
+          removeList: async (name: string) => {
+            const path = `${TODO_LISTS_DIR}/${name}`;
+            try {
+              await deleteFile(path);
+              if (get().selectedList === name) {
+                set({ selectedList: null, content: null, items: [] });
+              }
+              await get().refreshLists();
+            } catch (error) {
+              set({ error: error instanceof Error ? error.message : String(error) });
+            }
+          },
+          requestDeleteList: (name: string) => set({ pendingDeleteList: name, deleteModalOpen: true }),
+          cancelDeleteList: () => set({ deleteModalOpen: false, pendingDeleteList: null }),
+          confirmDeleteList: async () => {
+            const { pendingDeleteList } = get();
+            if (!pendingDeleteList) return;
 
-          set({ content: next, items: parseMarkdownTodos(next) });
+            await get().removeList(pendingDeleteList);
+            set({ pendingDeleteList: null, deleteModalOpen: false });
+          },
+          setChecked: async (line: number, checked: boolean) => {
+            const { selectedList, content } = get();
+            if (!selectedList || content == null) return;
 
-          try {
-            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-          } catch (error) {
-            set({
-              content: previous,
-              items: parseMarkdownTodos(previous),
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        },
-        addItem: async () => {
-          const { selectedList, content, newItemText } = get();
-          if (!selectedList) return;
+            const previous = content;
+            const next = toggleCheckboxAtLine(content, line, checked);
 
-          const text = newItemText.trim();
-          if (!text) return;
+            set({ content: next, items: parseMarkdownTodos(next) });
 
-          const previous = content ?? "";
-          const prefix = previous.endsWith("\n") || previous.length === 0 ? "" : "\n";
-          const next = previous + prefix + `- [ ] ${text}\n`;
+            try {
+              await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+            } catch (error) {
+              set({
+                content: previous,
+                items: parseMarkdownTodos(previous),
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          },
+          addItem: async () => {
+            const { selectedList, content, newItemText } = get();
+            if (!selectedList) return;
 
-          set({ content: next, items: parseMarkdownTodos(next), newItemText: "" });
+            const text = newItemText.trim();
+            if (!text) return;
 
-          try {
-            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-          } catch (error) {
-            set({
-              content: previous,
-              items: parseMarkdownTodos(previous),
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        },
-        removeItem: async (line: number) => {
-          const { selectedList, content } = get();
-          if (!selectedList || content == null) return;
+            const previous = content ?? "";
+            const prefix = previous.endsWith("\n") || previous.length === 0 ? "" : "\n";
+            const next = previous + prefix + `- [ ] ${text}\n`;
 
-          const lines = content.split("\n");
-          if (line < 0 || line >= lines.length) return;
+            set({ content: next, items: parseMarkdownTodos(next), newItemText: "" });
 
-          const previous = content;
-          lines.splice(line, 1);
-          const next = lines.join("\n");
+            try {
+              await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+            } catch (error) {
+              set({
+                content: previous,
+                items: parseMarkdownTodos(previous),
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          },
+          removeItem: async (line: number) => {
+            const { selectedList, content } = get();
+            if (!selectedList || content == null) return;
 
-          set({ content: next, items: parseMarkdownTodos(next) });
+            const lines = content.split("\n");
+            if (line < 0 || line >= lines.length) return;
 
-          try {
-            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-          } catch (error) {
-            set({
-              content: previous,
-              items: parseMarkdownTodos(previous),
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        },
-        startEditing: (line: number, currentText: string) => set({ editingLine: line, editingText: currentText }),
-        cancelEditing: () => set({ editingLine: null, editingText: "" }),
-        saveEditing: async () => {
-          const { editingLine, selectedList, content, editingText } = get();
-          if (editingLine == null || !selectedList || content == null) return;
+            const previous = content;
+            lines.splice(line, 1);
+            const next = lines.join("\n");
 
-          const next = replaceTodoTextAtLine(content, editingLine, editingText.trim());
+            set({ content: next, items: parseMarkdownTodos(next) });
 
-          set({ content: next, items: parseMarkdownTodos(next), editingLine: null, editingText: "" });
+            try {
+              await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+            } catch (error) {
+              set({
+                content: previous,
+                items: parseMarkdownTodos(previous),
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          },
+          startEditing: (line: number, currentText: string) => set({ editingLine: line, editingText: currentText }),
+          cancelEditing: () => set({ editingLine: null, editingText: "" }),
+          saveEditing: async () => {
+            const { editingLine, selectedList, content, editingText } = get();
+            if (editingLine == null || !selectedList || content == null) return;
 
-          try {
-            await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
-          } catch (error) {
-            set({
-              content,
-              items: parseMarkdownTodos(content),
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        },
-        initialize: async () => {
-          try {
-            await get().refreshLists();
-          } catch (error) {
-            set({ error: error instanceof Error ? error.message : String(error) });
-          }
-        },
-      })),
-      { name: "TodoStore" },
+            const next = replaceTodoTextAtLine(content, editingLine, editingText.trim());
+
+            set({ content: next, items: parseMarkdownTodos(next), editingLine: null, editingText: "" });
+
+            try {
+              await writeFile(`${TODO_LISTS_DIR}/${selectedList}`, next);
+            } catch (error) {
+              set({
+                content,
+                items: parseMarkdownTodos(content),
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          },
+          initialize: async () => {
+            try {
+              await get().refreshLists();
+            } catch (error) {
+              set({ error: error instanceof Error ? error.message : String(error) });
+            }
+          },
+          setError: (message: string | null) => set({ error: message }),
+        })),
+        { name: "TodoStore" },
+      ),
+      {
+        name: TODO_STORE_PERSIST_KEY,
+        filePath: persistFilePath,
+        version: TODO_STORE_PERSIST_VERSION,
+        partialize,
+        merge: (persistedState, currentState) => ({
+          ...currentState,
+          ...(persistedState as Partial<TodoStore>),
+        }),
+      },
     ),
   );
+};

--- a/clients/playground/src/services/state/opfsPersist.ts
+++ b/clients/playground/src/services/state/opfsPersist.ts
@@ -1,0 +1,81 @@
+import { deleteFile, readFile, writeFile } from "@pstdio/opfs-utils";
+import type { StateCreator, StoreMutatorIdentifier } from "zustand";
+import { createJSONStorage, persist, type PersistOptions, type StateStorage } from "zustand/middleware";
+
+function isNotFoundError(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: string }).name === "NotFoundError"
+  );
+}
+
+function createOpfsStateStorage(filePath: string) {
+  const storage: StateStorage<Promise<void>> = {
+    async getItem() {
+      try {
+        return await readFile(filePath);
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          return null;
+        }
+        console.warn(`[opfsPersist] Failed to read persisted state from "${filePath}"`, error);
+        return null;
+      }
+    },
+    async setItem(_name, value) {
+      try {
+        await writeFile(filePath, value);
+      } catch (error) {
+        console.error(`[opfsPersist] Failed to write persisted state to "${filePath}"`, error);
+        throw error;
+      }
+    },
+    async removeItem() {
+      try {
+        await deleteFile(filePath);
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          return;
+        }
+        console.error(`[opfsPersist] Failed to delete persisted state at "${filePath}"`, error);
+        throw error;
+      }
+    },
+  };
+
+  return storage;
+}
+
+export interface OpfsPersistOptions<T, PersistedState = Partial<T>>
+  extends Omit<PersistOptions<T, PersistedState>, "storage" | "name"> {
+  /**
+   * OPFS path for the persisted JSON file. The path is treated as relative to the
+   * OPFS root and parent directories are created automatically when needed.
+   */
+  filePath: string;
+  /**
+   * Optional name used by the devtools extension. Defaults to the file path when
+   * omitted.
+   */
+  name?: string;
+}
+
+export function persistToOpfs<
+  T,
+  Mps extends [StoreMutatorIdentifier, unknown][] = [],
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
+  PersistedState = Partial<T>,
+>(
+  initializer: StateCreator<T, [...Mps, ["zustand/persist", unknown]], Mcs>,
+  options: OpfsPersistOptions<T, PersistedState>,
+): StateCreator<T, Mps, [["zustand/persist", PersistedState], ...Mcs]> {
+  const { filePath, name, ...rest } = options;
+
+  return persist(initializer, {
+    ...rest,
+    name: name ?? filePath,
+    storage: createJSONStorage(() => createOpfsStateStorage(filePath)),
+  });
+}


### PR DESCRIPTION
## Summary
- add OPFS persistence to the todo store with configurable file path and state partialization
- make the OPFS persist helper default to saving partial slices of state and restore the workspace store to its prior configuration

## Testing
- npm run format:check
- npm run lint
- npx lerna run build
- npx lerna run test *(fails: Array.fromAsync is not available on Node 20)*

------
https://chatgpt.com/codex/tasks/task_e_68c9239afbe08321a9833a82678a6d7c