### PR TITLE
Fix quick start step numbering

### DIFF
--- a/clients/documentation/pages/getting-started/quick-start.md
+++ b/clients/documentation/pages/getting-started/quick-start.md
@@ -8,11 +8,11 @@ This Quick Start integrates the Kaset Agent (KAS) into your app so it can search
 
 You’ll:
 
-1. Install dependencies
-2. Initialize the agent with an OPFS workspace
-3. Build initial conversation and stream UI updates
-4. Auto‑commit changes to your workspace (optional)
-5. Browse files live in React (optional)
+1. Initialize the agent with an OPFS workspace
+2. Build initial conversation and stream UI updates (optional)
+3. Auto‑commit changes to your workspace (optional)
+4. Show files in React (optional)
+5. Seed the workspace (optional)
 
 ## KAS Installation
 
@@ -109,7 +109,7 @@ export function TodoViewer() {
 }
 ```
 
-## 4. Optional: seed the workspace
+## 5. Optional: Seed the workspace
 
 If the folder may not exist yet, write once to create it:
 


### PR DESCRIPTION
## Summary
- align the Quick Start "You'll" list with the numbered steps
- renumber the optional "Seed the workspace" section to keep step numbers increasing

## Testing
- npm run format:check
- npm run lint
- npx lerna run build
- npx lerna run test *(fails: Array.fromAsync is not a function in @pstdio/opfs-utils tests when running under Node 20)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7f16502c8321a98ba59c186656d9