### PR TITLE
docs: update approval gated tool examples

### DIFF
--- a/clients/documentation/pages/getting-started/quick-start.md
+++ b/clients/documentation/pages/getting-started/quick-start.md
@@ -40,7 +40,7 @@ const agent = createKasAgent({
   apiKey: "<YOUR_API_KEY>",
   workspaceDir,
   // Optional: customize which tools require approval
-  approvalGatedTools: ["opfs_write"],
+  approvalGatedTools: ["opfs_write_file"],
   // Require permission before the approval gated tool in this workspace
   requestApproval: async ({ tool, workspaceDir, detail }) => {
     console.log("Needs approval", tool, workspaceDir, detail);

--- a/packages/@pstdio/kas/README.md
+++ b/packages/@pstdio/kas/README.md
@@ -28,7 +28,7 @@ const agent = createKasAgent({
   apiKey: "<YOUR_API_KEY>",
   workspaceDir,
   // Optional: customize which tools require approval
-  approvalGatedTools: ["opfs_write"],
+  approvalGatedTools: ["opfs_write_file"],
   // Require permission before the approval gated tool in this workspace
   requestApproval: async ({ tool, workspaceDir, detail }) => {
     console.log("Needs approval", tool, workspaceDir, detail);


### PR DESCRIPTION
## Summary
- update the quick start guide to reference the supported `opfs_write_file` approval-gated tool
- keep the `@pstdio/kas` README example in sync with the documentation

## Testing
- npm run format:check
- npm run lint
- npx lerna run build
- npx lerna run test *(fails: Array.fromAsync is not a function in @pstdio/opfs-utils tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7f07ad588321ad3dd52fc053ccb4