### PR TITLE
Support Base URL-only connections in playground

### DIFF
--- a/clients/playground/src/components/conversation/ConversationArea/ConversationArea.tsx
+++ b/clients/playground/src/components/conversation/ConversationArea/ConversationArea.tsx
@@ -27,7 +27,7 @@ export const ConversationArea = (props: ConversationAreaProps) => {
 
   const [modelPricing, setModelPricing] = useState<ModelPricing | undefined>(undefined);
   const modelId = useWorkspaceStore((s) => s.modelId);
-  const hasKey = useWorkspaceStore((s) => !!s.apiKey);
+  const hasCredentials = useWorkspaceStore((s) => Boolean(s.apiKey || s.baseUrl));
   const settings = useDisclosure();
 
   // Load selected model from localStorage and resolve pricing
@@ -75,12 +75,12 @@ export const ConversationArea = (props: ConversationAreaProps) => {
               )}
             </Text>
           </Flex>
-          {!hasKey && (
+          {!hasCredentials && (
             <Alert.Root status="warning">
               <Alert.Indicator />
               <Alert.Content>
-                <Alert.Title fontWeight="bold">API key missing</Alert.Title>
-                <Alert.Description>Add your API key to enable chat.</Alert.Description>
+                <Alert.Title fontWeight="bold">Connection details missing</Alert.Title>
+                <Alert.Description>Add your API key or set a Base URL to enable chat.</Alert.Description>
                 <Button size="xs" variant="solid" onClick={settings.onOpen}>
                   Open Settings
                 </Button>

--- a/clients/playground/src/components/conversation/ConversationArea/MessageList.tsx
+++ b/clients/playground/src/components/conversation/ConversationArea/MessageList.tsx
@@ -136,7 +136,7 @@ interface MessageListProps {
 
 export function MessageList({ messages, streaming, onOpenFile, onUseExample }: MessageListProps) {
   const selectedProject = useWorkspaceStore((s) => s.selectedProjectId || "todo");
-  const hasKey = useWorkspaceStore((s) => !!s.apiKey);
+  const hasCredentials = useWorkspaceStore((s) => Boolean(s.apiKey || s.baseUrl));
 
   const projectPrompts = EXAMPLE_PROMPTS_BY_PROJECT[selectedProject] ?? EXAMPLE_PROMPTS_BY_PROJECT.todo;
   const examplesToShow = useMemo(() => pickRandom(projectPrompts, 4), [projectPrompts]);
@@ -161,7 +161,7 @@ export function MessageList({ messages, streaming, onOpenFile, onUseExample }: M
             </Link>
             .
           </Text>
-          {hasKey && (
+          {hasCredentials && (
             <VStack gap="sm" mt="sm" align="stretch">
               <Text textAlign="center" textStyle="label/S/regular" color="fg.muted">
                 Try one of these example prompts to get see it in action:

--- a/clients/playground/src/components/ui/conversation-host.tsx
+++ b/clients/playground/src/components/ui/conversation-host.tsx
@@ -36,7 +36,7 @@ export function ConversationHost() {
   );
 
   const [streaming, setStreaming] = useState(false);
-  const hasKey = useWorkspaceStore((s) => !!s.apiKey);
+  const hasCredentials = useWorkspaceStore((s) => Boolean(s.apiKey || s.baseUrl));
   const [approval, setApproval] = useState<ApprovalRequest | null>(null);
   const approvalResolve = useRef<((ok: boolean) => void) | null>(null);
 
@@ -127,7 +127,7 @@ export function ConversationHost() {
       <ConversationArea
         messages={messages}
         streaming={streaming}
-        canSend={hasKey && !streaming}
+        canSend={hasCredentials && !streaming}
         onSendMessage={handleSendMessage}
         onSelectFile={(path) => {
           const full = normalizeProjectPath(path);

--- a/clients/playground/src/components/ui/settings-modal.tsx
+++ b/clients/playground/src/components/ui/settings-modal.tsx
@@ -113,7 +113,7 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
                 </HStack>
               </Field.Root>
               <Field.Root>
-                <Field.Label>OpenAI Base URL (optional)</Field.Label>
+                <Field.Label>Base URL (optional)</Field.Label>
                 <Input
                   placeholder="https://api.openai.com/v1"
                   value={baseUrl}

--- a/clients/playground/src/services/ai/sendMessage.ts
+++ b/clients/playground/src/services/ai/sendMessage.ts
@@ -11,18 +11,15 @@ export async function* sendMessage(conversation: UIConversation) {
 
   const { initialForAgent, uiBoot, devNote } = await buildInitialConversation(conversation, dir);
 
-  const modelId = useWorkspaceStore.getState().modelId;
-  const apiKey = useWorkspaceStore.getState().apiKey!;
-  const baseURL = useWorkspaceStore.getState().baseUrl;
-  const approvalGatedTools = useWorkspaceStore.getState().approvalGatedTools;
+  const { modelId, apiKey, baseUrl, approvalGatedTools } = useWorkspaceStore.getState();
 
   const agent = createKasAgent({
     model: modelId,
-    apiKey,
-    baseURL,
     workspaceDir: dir,
     approvalGatedTools,
     requestApproval,
+    ...(apiKey ? { apiKey } : {}),
+    ...(baseUrl ? { baseURL: baseUrl } : {}),
   });
 
   for await (const ui of toConversation(agent(initialForAgent), { boot: uiBoot, devNote })) {

--- a/packages/@pstdio/kas/src/agent.ts
+++ b/packages/@pstdio/kas/src/agent.ts
@@ -5,7 +5,7 @@ import { createOpfsTools } from "./tools/createOpfsTools";
 
 export type CreateKasAgentOptions = {
   model: string;
-  apiKey: string;
+  apiKey?: string;
   workspaceDir: string;
   baseURL?: string;
   requestApproval?: RequestApproval;
@@ -19,14 +19,16 @@ export type CreateKasAgentOptions = {
 };
 
 export function createKasAgent(opts: CreateKasAgentOptions) {
-  if (!opts.apiKey) throw new Error("Missing OpenAI API key");
+  if (!opts.apiKey && !opts.baseURL) {
+    throw new Error("Missing OpenAI API key. Provide an API key or configure a Base URL.");
+  }
   if (!opts.model) throw new Error("Missing model");
   if (!opts.workspaceDir) throw new Error("Missing workspaceDir");
 
   const llm = createLLMTask({
     model: opts.model,
-    apiKey: opts.apiKey,
     reasoning: { effort: opts.effort ?? "low" },
+    ...(opts.apiKey ? { apiKey: opts.apiKey } : {}),
     ...(opts.baseURL ? { baseUrl: opts.baseURL } : {}),
     dangerouslyAllowBrowser: opts.dangerouslyAllowBrowser ?? true,
   });


### PR DESCRIPTION
## Summary
- allow `createKasAgent` to accept Base URL-only credentials and only pass an API key when provided
- update the playground UI to treat either an API key or Base URL as sufficient to send messages
- rename the playground settings field label to "Base URL (optional)"

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test` *(fails: Array.fromAsync is not a function under Node 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ca82d3a5e883218c0a3199dff09bed