### PR TITLE
Prevent initial auto scroll from shifting playground page

### DIFF
--- a/clients/playground/src/components/conversation/ConversationArea/AutoScroll.tsx
+++ b/clients/playground/src/components/conversation/ConversationArea/AutoScroll.tsx
@@ -1,26 +1,14 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 
 interface AutoScrollProps {
   userMessageCount: number;
 }
 
-const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
-
 export const AutoScroll = (props: AutoScrollProps) => {
   const { userMessageCount } = props;
   const { scrollToBottom } = useStickToBottomContext();
-  const hasScrolledInitiallyRef = useRef(false);
   const previousCountRef = useRef(userMessageCount);
-
-  useIsomorphicLayoutEffect(() => {
-    if (hasScrolledInitiallyRef.current) {
-      return;
-    }
-
-    hasScrolledInitiallyRef.current = true;
-    scrollToBottom({ animation: "instant" });
-  }, [scrollToBottom]);
 
   useEffect(() => {
     if (userMessageCount > previousCountRef.current) {

--- a/clients/playground/src/components/conversation/ConversationArea/AutoScroll.tsx
+++ b/clients/playground/src/components/conversation/ConversationArea/AutoScroll.tsx
@@ -1,11 +1,16 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 
 export const AutoScroll = ({ userMessageCount }: { userMessageCount: number }) => {
   const { scrollToBottom } = useStickToBottomContext();
+  const previousCountRef = useRef(userMessageCount);
 
   useEffect(() => {
-    scrollToBottom();
+    if (userMessageCount > previousCountRef.current) {
+      scrollToBottom();
+    }
+
+    previousCountRef.current = userMessageCount;
   }, [userMessageCount, scrollToBottom]);
 
   return null;

--- a/clients/playground/src/components/conversation/ConversationArea/AutoScroll.tsx
+++ b/clients/playground/src/components/conversation/ConversationArea/AutoScroll.tsx
@@ -1,9 +1,26 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 
-export const AutoScroll = ({ userMessageCount }: { userMessageCount: number }) => {
+interface AutoScrollProps {
+  userMessageCount: number;
+}
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+export const AutoScroll = (props: AutoScrollProps) => {
+  const { userMessageCount } = props;
   const { scrollToBottom } = useStickToBottomContext();
+  const hasScrolledInitiallyRef = useRef(false);
   const previousCountRef = useRef(userMessageCount);
+
+  useIsomorphicLayoutEffect(() => {
+    if (hasScrolledInitiallyRef.current) {
+      return;
+    }
+
+    hasScrolledInitiallyRef.current = true;
+    scrollToBottom({ animation: "instant" });
+  }, [scrollToBottom]);
 
   useEffect(() => {
     if (userMessageCount > previousCountRef.current) {


### PR DESCRIPTION
## Summary
- only trigger the chat auto-scroll when the user message count increases so the playground no longer jumps on initial load

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test` *(fails: @pstdio/opfs-utils relies on Array.fromAsync which isn't available in the current Node runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68cabb5da1b48321bb1e4eb014625de2