### PR TITLE
Remove clear action from playground settings

### DIFF
--- a/clients/playground/src/components/ui/settings-modal.tsx
+++ b/clients/playground/src/components/ui/settings-modal.tsx
@@ -56,23 +56,6 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
     onClose();
   };
 
-  const clear = () => {
-    useWorkspaceStore.setState(
-      (state) => {
-        state.apiKey = undefined;
-        state.baseUrl = undefined;
-        state.modelId = "gpt-5-mini";
-        state.approvalGatedTools = [...DEFAULT_APPROVAL_GATED_TOOLS];
-      },
-      false,
-      "settings/clear-llm-config",
-    );
-    setApiKey("");
-    setBaseUrl("");
-    setModel("gpt-5-mini");
-    setApprovalTools([...DEFAULT_APPROVAL_GATED_TOOLS]);
-  };
-
   return (
     <Dialog.Root open={isOpen} onOpenChange={(e) => !e.open && onClose()} closeOnInteractOutside={false}>
       <Dialog.Backdrop />
@@ -142,9 +125,6 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
             </VStack>
           </Dialog.Body>
           <Dialog.Footer gap="sm">
-            <Button variant="outline" onClick={clear}>
-              Clear
-            </Button>
             <Button onClick={save} variant="solid">
               Save
             </Button>


### PR DESCRIPTION
## Summary
- remove the clear action from the playground settings modal so the button no longer appears
- leave the save flow intact while keeping the existing configuration handling

## Testing
- npm run format:check
- npm run lint
- npx lerna run build
- npx lerna run test *(fails: Array.fromAsync is not a function across opfs-utils tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cadc89b9708321b0f2bf3c8c63b6f5