### PR TITLE
feat: implement browser plugin host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4493,6 +4493,10 @@
       "resolved": "packages/@pstdio/kas",
       "link": true
     },
+    "node_modules/@pstdio/kaset-plugin-host": {
+      "resolved": "packages/@pstdio/kaset-plugin-host",
+      "link": true
+    },
     "node_modules/@pstdio/opfs-hooks": {
       "resolved": "packages/@pstdio/opfs-hooks",
       "link": true
@@ -23069,6 +23073,24 @@
         "@types/node": "^22.15.18",
         "eslint": "^9.32.0",
         "typescript": "^5.7.3",
+        "vite": "^7.1.0",
+        "vite-plugin-dts": "^4.5.4",
+        "vitest": "^3.2.4"
+      }
+    },
+    "packages/@pstdio/kaset-plugin-host": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@pstdio/opfs-utils": "^0.1.6",
+        "ajv": "~8.13.0",
+        "ajv-formats": "^3.0.1",
+        "micromatch": "^4.0.8",
+        "semver": "^7.6.2"
+      },
+      "devDependencies": {
+        "@au-re/vite-plugin-externalize-deps": "^0.9.1",
+        "jsdom": "^26.1.0",
         "vite": "^7.1.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.2.4"

--- a/packages/@pstdio/kaset-plugin-host/package.json
+++ b/packages/@pstdio/kaset-plugin-host/package.json
@@ -41,7 +41,13 @@
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^3.2.4"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@pstdio/opfs-utils": "^0.1.6",
+    "ajv": "~8.13.0",
+    "ajv-formats": "^3.0.1",
+    "micromatch": "^4.0.8",
+    "semver": "^7.6.2"
+  },
   "volta": {
     "node": "22.18.0"
   }

--- a/packages/@pstdio/kaset-plugin-host/src/constants.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/constants.ts
@@ -1,0 +1,1 @@
+export const HOST_API_VERSION = "1.0.0";

--- a/packages/@pstdio/kaset-plugin-host/src/host/command-registry.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/command-registry.ts
@@ -1,0 +1,63 @@
+import type { CommandDefinition } from "../model/manifest";
+import type { RegisteredCommand, UIAdapter } from "./ui-adapter";
+
+export class CommandRegistry {
+  private readonly commands: RegisteredCommand[] = [];
+  private readonly byPlugin = new Map<string, Map<string, RegisteredCommand>>();
+
+  constructor(private readonly adapter: UIAdapter) {}
+
+  register(pluginId: string, definition: CommandDefinition, run: () => Promise<void>): RegisteredCommand {
+    if (!definition.id) {
+      throw new Error("Command definition is missing an id");
+    }
+    const existing = this.byPlugin.get(pluginId)?.get(definition.id);
+    if (existing) {
+      throw new Error(`Command already registered: ${pluginId}:${definition.id}`);
+    }
+    const command: RegisteredCommand = {
+      pluginId,
+      ...definition,
+      run,
+    };
+    if (!this.byPlugin.has(pluginId)) {
+      this.byPlugin.set(pluginId, new Map());
+    }
+    this.byPlugin.get(pluginId)!.set(definition.id, command);
+    this.commands.push(command);
+    this.adapter.onCommandsChanged(this.list());
+    return command;
+  }
+
+  unregister(pluginId: string, commandId: string): void {
+    const commandsForPlugin = this.byPlugin.get(pluginId);
+    if (!commandsForPlugin) return;
+    const command = commandsForPlugin.get(commandId);
+    if (!command) return;
+    commandsForPlugin.delete(commandId);
+    const index = this.commands.indexOf(command);
+    if (index >= 0) {
+      this.commands.splice(index, 1);
+    }
+    if (commandsForPlugin.size === 0) {
+      this.byPlugin.delete(pluginId);
+    }
+    this.adapter.onCommandsChanged(this.list());
+  }
+
+  removeAll(pluginId: string): void {
+    const commandsForPlugin = this.byPlugin.get(pluginId);
+    if (!commandsForPlugin) return;
+    for (const commandId of commandsForPlugin.keys()) {
+      this.unregister(pluginId, commandId);
+    }
+  }
+
+  find(pluginId: string, commandId: string): RegisteredCommand | undefined {
+    return this.byPlugin.get(pluginId)?.get(commandId);
+  }
+
+  list(): RegisteredCommand[] {
+    return [...this.commands];
+  }
+}

--- a/packages/@pstdio/kaset-plugin-host/src/host/context.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/context.ts
@@ -1,0 +1,145 @@
+import {
+  deleteFile,
+  grep,
+  ls,
+  moveFile,
+  patch,
+  processSingleFileContent,
+  readFile,
+  writeFile,
+} from "@pstdio/opfs-utils";
+import type { Manifest } from "../model/manifest";
+import { trimLeadingSlash } from "../utils/path";
+import { createEventHub } from "./events";
+import { createLogger } from "./logger";
+import type { PermissionChecker } from "./permissions";
+import { SchedulerController } from "./scheduler";
+import type { SettingsManager } from "./settings";
+import type { Disposable, Events, Logger, PluginContext, Scheduler, SettingsApi, UIHostApi } from "./types";
+
+type LsOptions = Parameters<typeof ls>[1];
+
+const normalizeFsPath = (path: string) => {
+  const cleaned = path.replace(/\\/g, "/").trim();
+  if (!cleaned) return "/";
+  return cleaned.startsWith("/") ? cleaned : `/${cleaned}`;
+};
+
+const toStoragePath = (path: string) => trimLeadingSlash(normalizeFsPath(path));
+
+export interface UIBridge {
+  notify(level: "info" | "warn" | "error", message: string): void;
+  invoke(pluginId: string, commandId: string): Promise<void>;
+  registerCommand(
+    pluginId: string,
+    definition: { id: string; title: string; category?: string; when?: string },
+    handler: () => Promise<void> | void,
+  ): Disposable;
+  unregisterCommand(pluginId: string, commandId: string): void;
+}
+
+export interface PluginRuntime {
+  context: PluginContext;
+  events: Events;
+  emit: Events["emit"];
+  disposeEvents: () => void;
+  scheduler: SchedulerController;
+  logger: Logger;
+}
+
+export const createPluginRuntime = (
+  manifest: Manifest,
+  permissionChecker: PermissionChecker,
+  settingsManager: SettingsManager,
+  uiBridge: UIBridge,
+  abortSignal: AbortSignal,
+  netFetch?: (url: string, init?: RequestInit) => Promise<Response>,
+): PluginRuntime => {
+  const logger = createLogger(manifest.id);
+  const scheduler = new SchedulerController(logger);
+  const eventHub = createEventHub(logger);
+
+  const expandForDirectoryCheck = (path: string) => {
+    const absolute = normalizeFsPath(path);
+    if (absolute === "/") return "/**";
+    return absolute.endsWith("/") ? `${absolute}**` : `${absolute}/**`;
+  };
+
+  const fsApi = {
+    async ls(path: string, options?: LsOptions) {
+      const absolute = normalizeFsPath(path);
+      permissionChecker.assertRead(expandForDirectoryCheck(absolute));
+      return ls(toStoragePath(absolute), options);
+    },
+    async readFile(path: string) {
+      const absolute = normalizeFsPath(path);
+      permissionChecker.assertRead(absolute);
+      return readFile(toStoragePath(absolute));
+    },
+    async writeFile(path: string, contents: string) {
+      const absolute = normalizeFsPath(path);
+      permissionChecker.assertWrite(absolute);
+      await writeFile(toStoragePath(absolute), contents);
+    },
+    async moveFile(fromPath: string, toPath: string) {
+      const fromAbsolute = normalizeFsPath(fromPath);
+      const toAbsolute = normalizeFsPath(toPath);
+      permissionChecker.assertWrite(fromAbsolute);
+      permissionChecker.assertWrite(toAbsolute);
+      await moveFile(toStoragePath(fromAbsolute), toStoragePath(toAbsolute));
+    },
+    async deleteFile(path: string) {
+      const absolute = normalizeFsPath(path);
+      permissionChecker.assertWrite(absolute);
+      await deleteFile(toStoragePath(absolute));
+    },
+  } satisfies PluginContext["fs"];
+
+  const settings: SettingsApi = {
+    read: async <T>() => settingsManager.read<T>(manifest.id),
+    write: async <T>(value: T) => settingsManager.write(manifest.id, value),
+  };
+
+  const ui: UIHostApi = {
+    notify: (level, message) => uiBridge.notify(level, message),
+    invoke: async (commandId: string) => uiBridge.invoke(manifest.id, commandId),
+    registerCommand: (definition, handler) => uiBridge.registerCommand(manifest.id, definition, handler),
+    unregisterCommand: (commandId: string) => uiBridge.unregisterCommand(manifest.id, commandId),
+  };
+
+  const net =
+    netFetch && manifest.permissions?.net?.length
+      ? {
+          fetch: async (url: string, init?: RequestInit) => {
+            permissionChecker.assertNet(url);
+            return netFetch(url, init);
+          },
+        }
+      : undefined;
+
+  const context: PluginContext = {
+    id: manifest.id,
+    manifest,
+    log: logger,
+    fs: fsApi,
+    grep,
+    patch,
+    processSingleFileContent,
+    settings,
+    ui,
+    scheduler: scheduler as Scheduler,
+    events: eventHub.api,
+    net,
+    cancelToken: abortSignal,
+    disposables: [],
+  };
+
+  return {
+    context,
+    events: eventHub.api,
+    emit: eventHub.emit,
+    disposeEvents: eventHub.dispose,
+    scheduler,
+    logger,
+  };
+};

--- a/packages/@pstdio/kaset-plugin-host/src/host/events.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/events.ts
@@ -1,0 +1,59 @@
+import type { Disposable, EventListener, Events, Logger } from "./types";
+
+export interface EventHub {
+  api: Events;
+  emit(name: string, payload?: unknown): void;
+  dispose(): void;
+}
+
+export const createEventHub = (logger?: Logger): EventHub => {
+  const listeners = new Map<string, Set<EventListener>>();
+
+  const off = (name: string, listener: EventListener) => {
+    const existing = listeners.get(name);
+    if (!existing) return;
+    existing.delete(listener);
+    if (existing.size === 0) {
+      listeners.delete(name);
+    }
+  };
+
+  const on = (name: string, listener: EventListener): Disposable => {
+    if (!listeners.has(name)) {
+      listeners.set(name, new Set());
+    }
+    listeners.get(name)!.add(listener);
+    return {
+      dispose: () => off(name, listener),
+    };
+  };
+
+  const emit = (name: string, payload?: unknown) => {
+    const handlers = listeners.get(name);
+    if (!handlers?.size) return;
+    for (const handler of [...handlers]) {
+      try {
+        const result = handler(payload);
+        if (result && typeof (result as Promise<unknown>).then === "function") {
+          (result as Promise<unknown>).catch((error) => {
+            logger?.error?.("event handler error", { name, error });
+          });
+        }
+      } catch (error) {
+        logger?.error?.("event handler error", { name, error });
+      }
+    }
+  };
+
+  const dispose = () => {
+    listeners.clear();
+  };
+
+  const api: Events = {
+    on,
+    off,
+    emit,
+  };
+
+  return { api, emit, dispose };
+};

--- a/packages/@pstdio/kaset-plugin-host/src/host/logger.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/logger.ts
@@ -1,0 +1,54 @@
+import { readFile, writeFile } from "@pstdio/opfs-utils";
+import { joinPath, trimLeadingSlash } from "../utils/path";
+import type { Logger } from "./types";
+
+const LOG_ROOT = "artifacts/logs";
+
+const toLogPath = (pluginId: string) => trimLeadingSlash(joinPath(LOG_ROOT, `${pluginId}.ndjson`));
+
+class PluginLogWriter {
+  private queue = Promise.resolve();
+
+  constructor(private readonly pluginId: string) {}
+
+  append(level: "info" | "warn" | "error", args: unknown[]): void {
+    this.queue = this.queue
+      .then(async () => {
+        const entry = {
+          ts: new Date().toISOString(),
+          level,
+          data: args.length <= 1 ? args[0] : args,
+        };
+        const serialized = JSON.stringify(entry);
+        const path = toLogPath(this.pluginId);
+        let existing = "";
+        try {
+          existing = await readFile(path);
+        } catch (error: any) {
+          if (error?.name !== "NotFoundError") {
+            throw error;
+          }
+        }
+        const next = existing ? `${existing}${serialized}\n` : `${serialized}\n`;
+        await writeFile(path, next);
+      })
+      .catch((error) => {
+        console.error("[kaset-plugin-host] failed to append log", error);
+      });
+  }
+}
+
+export const createLogger = (pluginId: string): Logger => {
+  const writer = new PluginLogWriter(pluginId);
+  return {
+    info: (...args) => {
+      writer.append("info", args);
+    },
+    warn: (...args) => {
+      writer.append("warn", args);
+    },
+    error: (...args) => {
+      writer.append("error", args);
+    },
+  };
+};

--- a/packages/@pstdio/kaset-plugin-host/src/host/permissions.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/permissions.ts
@@ -1,0 +1,108 @@
+import micromatch from "micromatch";
+import type { Manifest, Permissions } from "../model/manifest";
+import { ensureLeadingSlash } from "../utils/path";
+
+const PROTECTED_PATHS = ["/state/secure/**"];
+
+export interface PermissionChecker {
+  assertRead(path: string): void;
+  assertWrite(path: string): void;
+  canRead(path: string): boolean;
+  canWrite(path: string): boolean;
+  assertNet(url: string): void;
+  canUseNet(url: string): boolean;
+}
+
+interface NetRule {
+  protocols?: string[];
+  hostPattern: string;
+  port?: string;
+}
+
+const normalizePath = (value: string) => ensureLeadingSlash(value.replace(/\\/g, "/"));
+
+const matchAny = (path: string, patterns: string[] | undefined) => {
+  if (!patterns?.length) return false;
+  return micromatch.isMatch(path, patterns, { dot: true, nocase: false });
+};
+
+const buildNetRules = (permissions: Permissions | undefined): NetRule[] => {
+  const entries = permissions?.net ?? [];
+  return entries.map((entry) => {
+    if (!entry.includes("://")) {
+      return { hostPattern: entry };
+    }
+    try {
+      const url = new URL(entry);
+      const protocol = url.protocol.replace(/:$/, "");
+      return {
+        hostPattern: url.hostname || entry,
+        port: url.port || undefined,
+        protocols: protocol ? [protocol] : undefined,
+      };
+    } catch {
+      const [proto, rest] = entry.split("://");
+      return {
+        hostPattern: rest ?? entry,
+        protocols: proto ? [proto] : undefined,
+      };
+    }
+  });
+};
+
+const pathDenied = (path: string) => matchAny(path, PROTECTED_PATHS);
+
+export const createPermissionChecker = (manifest: Manifest): PermissionChecker => {
+  const fsPermissions = manifest.permissions?.fs;
+  const netRules = buildNetRules(manifest.permissions);
+
+  const canRead = (input: string) => {
+    const path = normalizePath(input);
+    if (pathDenied(path)) return false;
+    return matchAny(path, fsPermissions?.read);
+  };
+
+  const canWrite = (input: string) => {
+    const path = normalizePath(input);
+    if (pathDenied(path)) return false;
+    return matchAny(path, fsPermissions?.write);
+  };
+
+  const assertRead = (path: string) => {
+    if (!canRead(path)) {
+      throw new Error(`FS read denied: ${normalizePath(path)}`);
+    }
+  };
+
+  const assertWrite = (path: string) => {
+    if (!canWrite(path)) {
+      throw new Error(`FS write denied: ${normalizePath(path)}`);
+    }
+  };
+
+  const canUseNet = (urlStr: string) => {
+    if (!netRules.length) return false;
+    let url: URL;
+    try {
+      url = new URL(urlStr);
+    } catch {
+      return false;
+    }
+    const protocol = url.protocol.replace(/:$/, "");
+    const host = url.hostname;
+    const port = url.port || undefined;
+    return netRules.some((rule) => {
+      if (rule.protocols && !rule.protocols.includes(protocol)) return false;
+      if (rule.port && rule.port !== port) return false;
+      return micromatch.isMatch(host, rule.hostPattern, { nocase: true });
+    });
+  };
+
+  const assertNet = (url: string) => {
+    if (!canUseNet(url)) {
+      throw new Error(`Network access denied: ${url}`);
+    }
+  };
+
+  return { assertRead, assertWrite, canRead, canWrite, assertNet, canUseNet };
+};

--- a/packages/@pstdio/kaset-plugin-host/src/host/scheduler.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/scheduler.ts
@@ -1,0 +1,232 @@
+import type { Disposable, Logger, Scheduler } from "./types";
+
+interface CronSpec {
+  minutes: Set<number>;
+  hours: Set<number>;
+  daysOfMonth: Set<number>;
+  months: Set<number>;
+  daysOfWeek: Set<number>;
+  domWildcard: boolean;
+  dowWildcard: boolean;
+}
+
+const parseCronField = (field: string, min: number, max: number, map?: (value: number) => number) => {
+  const values = new Set<number>();
+  let wildcard = false;
+  const parts = field.split(",").filter(Boolean);
+  if (parts.length === 0) {
+    parts.push("*");
+  }
+  for (const part of parts) {
+    const [rangePartRaw, stepRaw] = part.split("/");
+    const step = stepRaw ? Number.parseInt(stepRaw, 10) : 1;
+    if (!Number.isFinite(step) || step <= 0) {
+      throw new Error(`Invalid cron step: ${part}`);
+    }
+    const rangePart = rangePartRaw ?? "*";
+    if (rangePart === "*" || rangePart === "?") {
+      wildcard = true;
+      for (let value = min; value <= max; value += step) {
+        values.add(map ? map(value) : value);
+      }
+      continue;
+    }
+    const [startRaw, endRaw] = rangePart.split("-");
+    let start = Number.parseInt(startRaw, 10);
+    let end = endRaw ? Number.parseInt(endRaw, 10) : start;
+    if (!Number.isFinite(start)) {
+      throw new Error(`Invalid cron range: ${part}`);
+    }
+    if (!Number.isFinite(end)) {
+      end = start;
+    }
+    if (map) {
+      start = map(start);
+      end = map(end);
+    }
+    if (start > end) {
+      [start, end] = [end, start];
+    }
+    start = Math.max(min, start);
+    end = Math.min(max, end);
+    for (let value = start; value <= end; value += step) {
+      values.add(value);
+    }
+  }
+  return { values, wildcard };
+};
+
+const parseCronExpression = (expr: string): CronSpec => {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length < 5) {
+    throw new Error(`Cron expression must have 5 fields: ${expr}`);
+  }
+  const [minuteField, hourField, dayOfMonthField, monthField, dayOfWeekField] = parts;
+  const minutes = parseCronField(minuteField, 0, 59);
+  const hours = parseCronField(hourField, 0, 23);
+  const months = parseCronField(monthField, 1, 12);
+  const daysOfMonth = parseCronField(dayOfMonthField, 1, 31);
+  const daysOfWeek = parseCronField(dayOfWeekField, 0, 6, (value) => (value === 7 ? 0 : value));
+  return {
+    minutes: minutes.values,
+    hours: hours.values,
+    months: months.values,
+    daysOfMonth: daysOfMonth.values,
+    daysOfWeek: daysOfWeek.values,
+    domWildcard: daysOfMonth.wildcard,
+    dowWildcard: daysOfWeek.wildcard,
+  };
+};
+
+const getNextOccurrence = (spec: CronSpec, from: Date): Date | null => {
+  const candidate = new Date(from.getTime());
+  candidate.setSeconds(0, 0);
+  candidate.setMinutes(candidate.getMinutes() + 1);
+  for (let i = 0; i < 525600; i += 1) {
+    const minute = candidate.getMinutes();
+    const hour = candidate.getHours();
+    const month = candidate.getMonth() + 1;
+    const day = candidate.getDate();
+    const dow = candidate.getDay();
+    if (!spec.minutes.has(minute)) {
+      candidate.setMinutes(candidate.getMinutes() + 1);
+      continue;
+    }
+    if (!spec.hours.has(hour)) {
+      candidate.setHours(candidate.getHours() + 1, 0, 0, 0);
+      continue;
+    }
+    if (!spec.months.has(month)) {
+      candidate.setMonth(candidate.getMonth() + 1, 1);
+      candidate.setHours(0, 0, 0, 0);
+      continue;
+    }
+    const dayMatches = spec.domWildcard || spec.daysOfMonth.has(day);
+    const dowMatches = spec.dowWildcard || spec.daysOfWeek.has(dow);
+    if (dayMatches || dowMatches) {
+      return new Date(candidate.getTime());
+    }
+    candidate.setDate(candidate.getDate() + 1);
+    candidate.setHours(0, 0, 0, 0);
+  }
+  return null;
+};
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+class TimeoutDisposable implements Disposable {
+  constructor(
+    private readonly handle: TimerHandle,
+    private readonly clear: (handle: TimerHandle) => void,
+  ) {}
+
+  dispose(): void {
+    this.clear(this.handle);
+  }
+}
+
+export class SchedulerController implements Scheduler, Disposable {
+  private readonly disposables = new Set<Disposable>();
+
+  constructor(private readonly logger?: Logger) {}
+
+  registerCron(expr: string, callback: () => void | Promise<void>): Disposable {
+    const spec = parseCronExpression(expr);
+    let disposed = false;
+    let timer: TimerHandle | null = null;
+
+    const scheduleNext = (from: Date) => {
+      if (disposed) return;
+      const next = getNextOccurrence(spec, from);
+      if (!next) {
+        this.logger?.warn?.("Cron expression produced no future runs", { expr });
+        return;
+      }
+      const delay = Math.max(0, next.getTime() - Date.now());
+      timer = setTimeout(async () => {
+        if (disposed) return;
+        try {
+          await callback();
+        } catch (error) {
+          this.logger?.error?.("Cron job error", { expr, error });
+        } finally {
+          scheduleNext(new Date());
+        }
+      }, delay);
+    };
+
+    scheduleNext(new Date());
+
+    const disposable: Disposable = {
+      dispose: () => {
+        if (this.disposables.has(disposable)) {
+          this.disposables.delete(disposable);
+        }
+        disposed = true;
+        if (timer != null) {
+          clearTimeout(timer);
+        }
+      },
+    };
+    this.disposables.add(disposable);
+    return disposable;
+  }
+
+  setTimeout(callback: () => void | Promise<void>, delayMs: number): Disposable {
+    const handle = setTimeout(() => {
+      this.execute(callback);
+    }, delayMs);
+    const disposable = new TimeoutDisposable(handle, clearTimeout);
+    const wrapped: Disposable = {
+      dispose: () => {
+        if (this.disposables.has(wrapped)) {
+          this.disposables.delete(wrapped);
+        }
+        disposable.dispose();
+      },
+    };
+    this.disposables.add(wrapped);
+    return wrapped;
+  }
+
+  setInterval(callback: () => void | Promise<void>, intervalMs: number): Disposable {
+    const handle = setInterval(() => {
+      this.execute(callback);
+    }, intervalMs);
+    const disposable = new TimeoutDisposable(handle, clearInterval);
+    const wrapped: Disposable = {
+      dispose: () => {
+        if (this.disposables.has(wrapped)) {
+          this.disposables.delete(wrapped);
+        }
+        disposable.dispose();
+      },
+    };
+    this.disposables.add(wrapped);
+    return wrapped;
+  }
+
+  dispose(): void {
+    for (const disposable of this.disposables) {
+      try {
+        disposable.dispose();
+      } catch (error) {
+        this.logger?.error?.("Failed to dispose scheduler resource", error);
+      }
+    }
+    this.disposables.clear();
+  }
+
+  private execute(callback: () => void | Promise<void>) {
+    try {
+      const result = callback();
+      if (result && typeof (result as Promise<void>).then === "function") {
+        (result as Promise<void>).catch((error) => {
+          this.logger?.error?.("Scheduled task failed", error);
+        });
+      }
+    } catch (error) {
+      this.logger?.error?.("Scheduled task failed", error);
+    }
+  }
+}

--- a/packages/@pstdio/kaset-plugin-host/src/host/settings.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/settings.ts
@@ -1,0 +1,101 @@
+import Ajv, { type ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
+import { readFile, writeFile } from "@pstdio/opfs-utils";
+import type { JSONSchema } from "../model/manifest";
+import { joinPath, trimLeadingSlash } from "../utils/path";
+import { clone } from "../utils/object";
+import { SettingsValidationError, type SettingsValidationErrorDetail } from "./types";
+
+const SETTINGS_ROOT = "state/public/plugins";
+
+const toSettingsPath = (pluginId: string) => trimLeadingSlash(joinPath(SETTINGS_ROOT, `${pluginId}.json`));
+
+const createAjv = () => {
+  const ajv = new Ajv({ allErrors: true, useDefaults: true });
+  addFormats(ajv as any);
+  return ajv;
+};
+
+const normalizeErrors = (errors: ValidateFunction["errors"] | null | undefined): SettingsValidationErrorDetail[] => {
+  if (!errors?.length) return [];
+  return errors.map((error) => ({
+    message: error.message ?? "Invalid value",
+    path:
+      (typeof (error as any).instancePath === "string" && (error as any).instancePath) ||
+      (typeof (error as any).dataPath === "string" && (error as any).dataPath) ||
+      error.schemaPath ||
+      "",
+  }));
+};
+
+export class SettingsManager {
+  private readonly ajv = createAjv();
+  private readonly validators = new Map<string, ValidateFunction>();
+  private readonly defaults = new Map<string, unknown>();
+  private readonly schemas = new Map<string, JSONSchema>();
+
+  registerSchema(pluginId: string, schema?: JSONSchema): void {
+    if (!schema) {
+      this.validators.delete(pluginId);
+      this.defaults.delete(pluginId);
+      this.schemas.delete(pluginId);
+      return;
+    }
+    const validate = this.ajv.compile(schema);
+    const defaultsSource: Record<string, unknown> = {};
+    const valid = validate(defaultsSource);
+    if (valid) {
+      this.defaults.set(pluginId, clone(defaultsSource));
+    } else {
+      this.defaults.delete(pluginId);
+    }
+    this.validators.set(pluginId, validate);
+    this.schemas.set(pluginId, schema);
+  }
+
+  getSchema(pluginId: string): JSONSchema | undefined {
+    return this.schemas.get(pluginId);
+  }
+
+  async read<T = unknown>(pluginId: string): Promise<T> {
+    const validator = this.validators.get(pluginId);
+    const path = toSettingsPath(pluginId);
+    let payload: unknown;
+    try {
+      const raw = await readFile(path);
+      payload = JSON.parse(raw);
+    } catch (error: any) {
+      if (error?.name !== "NotFoundError") {
+        throw error;
+      }
+      payload = this.defaults.has(pluginId) ? clone(this.defaults.get(pluginId)) : {};
+      return payload as T;
+    }
+    if (!validator) {
+      return payload as T;
+    }
+    const data = clone(payload);
+    const ok = validator(data);
+    if (!ok) {
+      throw new SettingsValidationError("Settings validation failed", normalizeErrors(validator.errors));
+    }
+    return data as T;
+  }
+
+  async write<T = unknown>(pluginId: string, value: T): Promise<void> {
+    const validator = this.validators.get(pluginId);
+    const path = toSettingsPath(pluginId);
+    if (!validator) {
+      const serialized = JSON.stringify(value, null, 2);
+      await writeFile(path, serialized);
+      return;
+    }
+    const data = clone(value);
+    const ok = validator(data as any);
+    if (!ok) {
+      throw new SettingsValidationError("Settings validation failed", normalizeErrors(validator.errors));
+    }
+    const serialized = JSON.stringify(data, null, 2);
+    await writeFile(path, serialized);
+  }
+}

--- a/packages/@pstdio/kaset-plugin-host/src/host/types.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/types.ts
@@ -1,0 +1,97 @@
+import type { ls } from "@pstdio/opfs-utils";
+import type { Manifest } from "../model/manifest";
+
+type OpfsLs = typeof ls;
+
+export interface Disposable {
+  dispose(): void | Promise<void>;
+}
+
+export interface FSApi {
+  ls: (...args: Parameters<OpfsLs>) => ReturnType<OpfsLs>;
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, contents: string): Promise<void>;
+  moveFile(fromPath: string, toPath: string): Promise<void>;
+  deleteFile(path: string): Promise<void>;
+}
+
+export type Grep = (typeof import("@pstdio/opfs-utils"))["grep"];
+export type Patch = (typeof import("@pstdio/opfs-utils"))["patch"];
+export type ProcessSingleFileContent = (typeof import("@pstdio/opfs-utils"))["processSingleFileContent"];
+
+export interface SettingsApi {
+  read<T = unknown>(): Promise<T>;
+  write<T = unknown>(value: T): Promise<void>;
+}
+
+export interface UIHostApi {
+  notify?(level: "info" | "warn" | "error", message: string): void;
+  invoke(commandId: string): Promise<void>;
+  registerCommand(
+    definition: { id: string; title: string; category?: string; when?: string },
+    handler: () => Promise<void> | void,
+  ): Disposable;
+  unregisterCommand(commandId: string): void;
+}
+
+export interface Scheduler {
+  registerCron(expr: string, callback: () => void | Promise<void>): Disposable;
+  setTimeout(callback: () => void | Promise<void>, delayMs: number): Disposable;
+  setInterval(callback: () => void | Promise<void>, intervalMs: number): Disposable;
+}
+
+export type EventListener = (payload: unknown) => void | Promise<void>;
+
+export interface Events {
+  on(name: string, listener: EventListener): Disposable;
+  off(name: string, listener: EventListener): void;
+  emit(name: string, payload?: unknown): void;
+}
+
+export interface Logger {
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+export interface PluginContext {
+  id: string;
+  manifest: Manifest;
+  log: Logger;
+  fs: FSApi;
+  grep: Grep;
+  patch: Patch;
+  processSingleFileContent: ProcessSingleFileContent;
+  settings: SettingsApi;
+  ui: UIHostApi;
+  scheduler: Scheduler;
+  events: Events;
+  net?: { fetch: (url: string, init?: RequestInit) => Promise<Response> };
+  cancelToken: AbortSignal;
+  disposables: Disposable[];
+}
+
+export type AppEventUnsubscribe = () => void;
+
+export interface AppEvents {
+  on(name: string, listener: (payload: unknown) => void): AppEventUnsubscribe | void;
+}
+
+export interface RegisteredEventEmitter {
+  emit(name: string, payload?: unknown): void;
+}
+
+export interface SettingsValidationErrorDetail {
+  message: string;
+  path: string;
+}
+
+export class SettingsValidationError extends Error {
+  details: SettingsValidationErrorDetail[];
+
+  constructor(message: string, details: SettingsValidationErrorDetail[]) {
+    super(message);
+    this.name = "SettingsValidationError";
+    this.details = details;
+  }
+}

--- a/packages/@pstdio/kaset-plugin-host/src/host/ui-adapter.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/host/ui-adapter.ts
@@ -1,0 +1,26 @@
+import type { CommandDefinition, JSONSchema } from "../model/manifest";
+
+export interface RegisteredCommand extends CommandDefinition {
+  pluginId: string;
+  run: () => Promise<void>;
+}
+
+export interface UIAdapter {
+  onCommandsChanged(commands: RegisteredCommand[]): void;
+  notify?(level: "info" | "warn" | "error", message: string): void;
+  onSettingsSchema?(pluginId: string, schema?: JSONSchema): void;
+}
+
+export const createConsoleUIAdapter = (): UIAdapter => ({
+  onCommandsChanged(commands) {
+    if (commands.length === 0) {
+      return;
+    }
+    const titles = commands.map((command) => `${command.pluginId}:${command.id}`).join(", ");
+    console.debug("[kaset-plugin-host] commands:", titles);
+  },
+  notify(level, message) {
+    const method = level === "error" ? "error" : level === "warn" ? "warn" : "info";
+    console[method]?.(`[plugin] ${message}`);
+  },
+});

--- a/packages/@pstdio/kaset-plugin-host/src/index.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/index.ts
@@ -1,1 +1,547 @@
-export const placeholder = "kaset-plugin-host";
+import { ls, readFile, watchDirectory, type ChangeRecord, type DirectoryWatcherCleanup } from "@pstdio/opfs-utils";
+import micromatch from "micromatch";
+import { satisfies } from "semver";
+import { HOST_API_VERSION } from "./constants";
+import type { ActivationEvent, Manifest, JSONSchema } from "./model/manifest";
+import type { Plugin, PluginCommand, PluginModule } from "./model/plugin";
+import { createPluginRuntime, type PluginRuntime, type UIBridge } from "./host/context";
+import { CommandRegistry } from "./host/command-registry";
+import { createPermissionChecker, type PermissionChecker } from "./host/permissions";
+import { SettingsManager } from "./host/settings";
+import type { RegisteredCommand, UIAdapter } from "./host/ui-adapter";
+import { createConsoleUIAdapter } from "./host/ui-adapter";
+import type { AppEvents, Disposable } from "./host/types";
+import { withBudget } from "./utils/async";
+import { disposeAll } from "./utils/dispose";
+import { joinPath, trimLeadingSlash } from "./utils/path";
+
+const DEFAULT_TIMEOUTS = {
+  activate: 10_000,
+  deactivate: 5_000,
+  command: 10_000,
+};
+
+interface TimeoutConfig {
+  activate: number;
+  deactivate: number;
+  command: number;
+}
+
+export interface HostConfig {
+  pluginsRoot?: string;
+  watchPlugins?: boolean;
+  ui?: UIAdapter;
+  netFetch?: (url: string, init?: RequestInit) => Promise<Response>;
+  appEvents?: AppEvents;
+  fsWatcher?: boolean;
+  timeouts?: Partial<TimeoutConfig>;
+}
+
+export interface PluginHost {
+  loadAll(): Promise<void>;
+  unloadAll(): Promise<void>;
+  reloadPlugin(id: string): Promise<void>;
+  invokeCommand(pluginId: string, commandId: string): Promise<void>;
+  listCommands(): RegisteredCommand[];
+  emit(name: string, payload?: unknown): void;
+  getSettingsSchema(pluginId: string): JSONSchema | undefined;
+  readSettings<T = unknown>(pluginId: string): Promise<T>;
+  writeSettings<T = unknown>(pluginId: string, value: T): Promise<void>;
+}
+
+interface ResolvedHostConfig {
+  pluginsRoot: string;
+  pluginsRootRelative: string;
+  watchPlugins: boolean;
+  ui: UIAdapter;
+  netFetch?: (url: string, init?: RequestInit) => Promise<Response>;
+  appEvents?: AppEvents;
+  fsWatcher: boolean;
+  timeouts: TimeoutConfig;
+}
+
+interface LoadedPlugin {
+  id: string;
+  directory: string;
+  manifest: Manifest;
+  module: PluginModule;
+  plugin: Plugin;
+  runtime: PluginRuntime;
+  abortController: AbortController;
+  blobUrl: string;
+  commandIds: Set<string>;
+  activationDisposables: Disposable[];
+  eventNames: Set<string>;
+  permissionChecker: PermissionChecker;
+}
+
+const toRelativePath = (path: string) => trimLeadingSlash(path || "");
+
+const createDisposable = (fn: () => void): Disposable => ({
+  dispose: () => fn(),
+});
+
+class KasetPluginHost implements PluginHost {
+  private readonly config: ResolvedHostConfig;
+  private readonly settings = new SettingsManager();
+  private readonly ui: UIAdapter;
+  private readonly commandRegistry: CommandRegistry;
+  private readonly plugins = new Map<string, LoadedPlugin>();
+  private readonly directoryIndex = new Map<string, string>();
+  private pluginWatcherCleanup?: DirectoryWatcherCleanup;
+  private readonly reloadQueues = new Map<string, Promise<void>>();
+  private readonly appEventSubscriptions = new Map<string, { count: number; unsubscribe?: () => void }>();
+  private readonly eventListeners = new Map<string, Set<string>>();
+
+  constructor(cfg: HostConfig = {}) {
+    const pluginsRoot = cfg.pluginsRoot ?? "/plugins";
+    const pluginsRootRelative = toRelativePath(pluginsRoot);
+    const timeouts: TimeoutConfig = {
+      activate: cfg.timeouts?.activate ?? DEFAULT_TIMEOUTS.activate,
+      deactivate: cfg.timeouts?.deactivate ?? DEFAULT_TIMEOUTS.deactivate,
+      command: cfg.timeouts?.command ?? DEFAULT_TIMEOUTS.command,
+    };
+    this.config = {
+      pluginsRoot,
+      pluginsRootRelative,
+      watchPlugins: cfg.watchPlugins ?? true,
+      ui: cfg.ui ?? createConsoleUIAdapter(),
+      netFetch: cfg.netFetch,
+      appEvents: cfg.appEvents,
+      fsWatcher: cfg.fsWatcher ?? true,
+      timeouts,
+    };
+    this.ui = this.config.ui;
+    this.commandRegistry = new CommandRegistry(this.ui);
+  }
+
+  async loadAll(): Promise<void> {
+    await this.loadFromDisk();
+    if (this.config.watchPlugins) {
+      await this.startPluginWatcher();
+    }
+  }
+
+  async unloadAll(): Promise<void> {
+    const plugins = [...this.plugins.keys()];
+    for (const id of plugins) {
+      await this.unloadPlugin(id);
+    }
+    if (this.pluginWatcherCleanup) {
+      this.pluginWatcherCleanup();
+      this.pluginWatcherCleanup = undefined;
+    }
+  }
+
+  async reloadPlugin(id: string): Promise<void> {
+    await this.enqueueReload(id, async () => {
+      const existing = this.plugins.get(id);
+      const directory = existing?.directory ?? joinPath(this.config.pluginsRootRelative, id);
+      if (existing) {
+        await this.unloadPlugin(id);
+      }
+      await this.loadPluginFromDirectory(directory).catch((error) => {
+        console.error("[kaset-plugin-host] Failed to reload plugin", id, error);
+      });
+    });
+  }
+
+  async invokeCommand(pluginId: string, commandId: string): Promise<void> {
+    const command = this.commandRegistry.find(pluginId, commandId);
+    if (!command) {
+      throw new Error(`Command not found: ${pluginId}:${commandId}`);
+    }
+    await command.run();
+  }
+
+  listCommands(): RegisteredCommand[] {
+    return this.commandRegistry.list();
+  }
+
+  emit(name: string, payload?: unknown): void {
+    const targets = this.eventListeners.get(name);
+    if (!targets?.size) return;
+    for (const pluginId of targets) {
+      const plugin = this.plugins.get(pluginId);
+      if (!plugin) continue;
+      try {
+        plugin.runtime.emit(name, payload);
+      } catch (error) {
+        plugin.runtime.logger.error("Failed to emit event", { name, error });
+      }
+    }
+  }
+
+  getSettingsSchema(pluginId: string): JSONSchema | undefined {
+    return this.settings.getSchema(pluginId);
+  }
+
+  async readSettings<T = unknown>(pluginId: string): Promise<T> {
+    return this.settings.read<T>(pluginId);
+  }
+
+  async writeSettings<T = unknown>(pluginId: string, value: T): Promise<void> {
+    await this.settings.write(pluginId, value);
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    let entries: Awaited<ReturnType<typeof ls>> = [];
+    try {
+      entries = await ls(this.config.pluginsRootRelative, { maxDepth: 1, kinds: ["directory"] });
+    } catch (error) {
+      console.warn("[kaset-plugin-host] Unable to list plugins", error);
+      return;
+    }
+    for (const entry of entries) {
+      const dir = joinPath(this.config.pluginsRootRelative, entry.path);
+      await this.loadPluginFromDirectory(dir).catch((error) => {
+        console.error("[kaset-plugin-host] Failed to load plugin", entry.path, error);
+      });
+    }
+  }
+
+  private async startPluginWatcher(): Promise<void> {
+    if (this.pluginWatcherCleanup) return;
+    try {
+      this.pluginWatcherCleanup = await watchDirectory(
+        this.config.pluginsRootRelative,
+        (changes) => this.handlePluginDirectoryChanges(changes),
+        { recursive: true, emitInitial: false },
+      );
+    } catch (error) {
+      console.warn("[kaset-plugin-host] Failed to watch plugins directory", error);
+    }
+  }
+
+  private async handlePluginDirectoryChanges(changes: ChangeRecord[]): Promise<void> {
+    const touched = new Set<string>();
+    for (const change of changes) {
+      if (!change.path?.length) continue;
+      const [dir] = change.path;
+      if (dir) touched.add(dir);
+    }
+    for (const dir of touched) {
+      const relative = joinPath(this.config.pluginsRootRelative, dir);
+      await this.enqueueReload(relative, async () => {
+        const existingId = this.directoryIndex.get(relative);
+        if (existingId) {
+          await this.unloadPlugin(existingId);
+        }
+        await this.loadPluginFromDirectory(relative).catch((error) => {
+          console.error("[kaset-plugin-host] Failed to reload directory", relative, error);
+        });
+      });
+    }
+  }
+
+  private async enqueueReload(key: string, task: () => Promise<void>): Promise<void> {
+    const previous = this.reloadQueues.get(key) ?? Promise.resolve();
+    const next = previous
+      .catch(() => undefined)
+      .then(task)
+      .catch((error) => {
+        console.error("[kaset-plugin-host] Reload task failed", error);
+      })
+      .finally(() => {
+        if (this.reloadQueues.get(key) === next) {
+          this.reloadQueues.delete(key);
+        }
+      });
+    this.reloadQueues.set(key, next);
+    await next;
+  }
+
+  private async loadPluginFromDirectory(directory: string): Promise<void> {
+    const manifestPath = joinPath(directory, "manifest.json");
+    let manifestRaw: string;
+    try {
+      manifestRaw = await readFile(toRelativePath(manifestPath));
+    } catch (error) {
+      throw new Error(`Failed to read manifest at ${manifestPath}: ${error instanceof Error ? error.message : error}`);
+    }
+    let manifest: Manifest;
+    try {
+      manifest = JSON.parse(manifestRaw) as Manifest;
+    } catch (error) {
+      throw new Error(`Invalid manifest JSON at ${manifestPath}: ${error instanceof Error ? error.message : error}`);
+    }
+    if (!manifest.id) {
+      throw new Error(`Manifest at ${manifestPath} is missing an id`);
+    }
+    if (!manifest.entry) {
+      throw new Error(`Manifest for ${manifest.id} is missing an entry field`);
+    }
+    if (!satisfies(HOST_API_VERSION, manifest.api)) {
+      throw new Error(`Plugin ${manifest.id} requires host api ${manifest.api}`);
+    }
+
+    const entryPath = joinPath(directory, manifest.entry);
+    let code: string;
+    try {
+      code = await readFile(toRelativePath(entryPath));
+    } catch (error) {
+      throw new Error(
+        `Failed to read entry module for ${manifest.id}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+
+    const blob = new Blob([code], { type: "text/javascript" });
+    const url = URL.createObjectURL(blob);
+    let mod: PluginModule;
+    try {
+      mod = (await import(/* @vite-ignore */ url)) as PluginModule;
+    } catch (error) {
+      URL.revokeObjectURL(url);
+      throw new Error(`Failed to import plugin ${manifest.id}: ${error instanceof Error ? error.message : error}`);
+    }
+
+    const pluginExport = (mod.default ?? mod) as Plugin;
+    if (!pluginExport || typeof pluginExport.activate !== "function") {
+      URL.revokeObjectURL(url);
+      throw new Error(`Plugin ${manifest.id} must export an activate function`);
+    }
+
+    const abortController = new AbortController();
+    const permissionChecker = createPermissionChecker(manifest);
+
+    this.settings.registerSchema(manifest.id, manifest.settingsSchema);
+    this.ui.onSettingsSchema?.(manifest.id, manifest.settingsSchema);
+
+    const commandIds = new Set<string>();
+    const activationDisposables: Disposable[] = [];
+    const eventNames = new Set<string>();
+    const runtimeRef: { current?: PluginRuntime } = {};
+
+    const uiBridge: UIBridge = {
+      notify: (level, message) => {
+        this.ui.notify?.(level, message);
+      },
+      invoke: (pluginId, commandId) => this.invokeCommand(pluginId, commandId),
+      registerCommand: (pluginId, definition, handler) => {
+        const runtime = runtimeRef.current;
+        if (!runtime) throw new Error("Plugin runtime is not ready");
+        const wrapped = async () => {
+          try {
+            await withBudget(
+              () => Promise.resolve(handler()),
+              this.config.timeouts.command,
+              runtime.context.cancelToken,
+            );
+          } catch (error) {
+            runtime.logger.error("Command handler failed", { command: definition.id, error });
+            throw error;
+          }
+        };
+        const command = this.commandRegistry.register(pluginId, definition, wrapped);
+        commandIds.add(command.id);
+        return {
+          dispose: () => {
+            if (commandIds.has(command.id)) {
+              commandIds.delete(command.id);
+              this.commandRegistry.unregister(pluginId, command.id);
+            }
+          },
+        };
+      },
+      unregisterCommand: (pluginId, commandId) => {
+        if (commandIds.has(commandId)) {
+          commandIds.delete(commandId);
+          this.commandRegistry.unregister(pluginId, commandId);
+        }
+      },
+    };
+
+    const runtime = createPluginRuntime(
+      manifest,
+      permissionChecker,
+      this.settings,
+      uiBridge,
+      abortController.signal,
+      this.config.netFetch,
+    );
+    runtimeRef.current = runtime;
+
+    try {
+      await withBudget(
+        () => pluginExport.activate(runtime.context),
+        this.config.timeouts.activate,
+        abortController.signal,
+      );
+    } catch (error) {
+      abortController.abort();
+      runtime.scheduler.dispose();
+      runtime.disposeEvents();
+      this.settings.registerSchema(manifest.id, undefined);
+      this.ui.onSettingsSchema?.(manifest.id, undefined);
+      URL.revokeObjectURL(url);
+      throw error;
+    }
+
+    const commands = manifest.ui?.commands ?? [];
+    const commandImpls = (mod.commands ?? {}) as Record<string, PluginCommand>;
+    for (const definition of commands) {
+      const handler = commandImpls[definition.id];
+      if (typeof handler !== "function") {
+        runtime.logger.warn("Command declared but not implemented", { command: definition.id });
+        continue;
+      }
+      const wrapped = async () => {
+        try {
+          await withBudget(() => handler(runtime.context), this.config.timeouts.command, runtime.context.cancelToken);
+        } catch (error) {
+          runtime.logger.error("Command failed", { command: definition.id, error });
+          throw error;
+        }
+      };
+      this.commandRegistry.register(manifest.id, definition, wrapped);
+      commandIds.add(definition.id);
+    }
+
+    const loaded: LoadedPlugin = {
+      id: manifest.id,
+      directory,
+      manifest,
+      module: mod,
+      plugin: pluginExport,
+      runtime,
+      abortController,
+      blobUrl: url,
+      commandIds,
+      activationDisposables,
+      eventNames,
+      permissionChecker,
+    };
+
+    await this.setupActivationHandlers(loaded);
+
+    this.plugins.set(manifest.id, loaded);
+    this.directoryIndex.set(directory, manifest.id);
+  }
+
+  private async setupActivationHandlers(plugin: LoadedPlugin): Promise<void> {
+    const activations = plugin.manifest.activation ?? [];
+    const fsChanges = activations.filter((activation) => activation.type === "onFSChange") as Array<
+      Extract<ActivationEvent, { type: "onFSChange" }>
+    >;
+    if (fsChanges.length) {
+      if (!this.config.fsWatcher) {
+        plugin.runtime.logger.warn("FS change activations requested but fsWatcher is disabled");
+      } else {
+        const cleanup = await watchDirectory(
+          "",
+          (changes) => {
+            for (const change of changes) {
+              const path = `/${change.path.join("/")}`;
+              if (!plugin.permissionChecker.canRead(path)) continue;
+              for (const activation of fsChanges) {
+                if (micromatch.isMatch(path, activation.glob, { dot: true })) {
+                  plugin.runtime.emit("fs:change", { glob: activation.glob, change, path });
+                }
+              }
+            }
+          },
+          { recursive: true, emitInitial: false },
+        );
+        plugin.activationDisposables.push(createDisposable(cleanup));
+      }
+    }
+
+    const cronActivations = activations.filter((activation) => activation.type === "onCron") as Array<
+      Extract<ActivationEvent, { type: "onCron" }>
+    >;
+    for (const activation of cronActivations) {
+      const disposable = plugin.runtime.scheduler.registerCron(activation.expr, () => {
+        plugin.runtime.emit("cron", { expr: activation.expr });
+      });
+      plugin.activationDisposables.push(disposable);
+    }
+
+    const eventActivations = activations.filter((activation) => activation.type === "onEvent") as Array<
+      Extract<ActivationEvent, { type: "onEvent" }>
+    >;
+    for (const activation of eventActivations) {
+      plugin.eventNames.add(activation.name);
+      if (!this.eventListeners.has(activation.name)) {
+        this.eventListeners.set(activation.name, new Set());
+      }
+      this.eventListeners.get(activation.name)!.add(plugin.id);
+      this.subscribeAppEvent(activation.name);
+    }
+  }
+
+  private subscribeAppEvent(name: string): void {
+    const entry = this.appEventSubscriptions.get(name);
+    if (entry) {
+      entry.count += 1;
+      return;
+    }
+    let unsubscribe: (() => void) | undefined;
+    if (this.config.appEvents) {
+      const result = this.config.appEvents.on(name, (payload) => this.emit(name, payload));
+      if (typeof result === "function") {
+        unsubscribe = result;
+      }
+    }
+    this.appEventSubscriptions.set(name, { count: 1, unsubscribe });
+  }
+
+  private unsubscribeAppEvent(name: string): void {
+    const entry = this.appEventSubscriptions.get(name);
+    if (!entry) return;
+    entry.count -= 1;
+    if (entry.count <= 0) {
+      entry.unsubscribe?.();
+      this.appEventSubscriptions.delete(name);
+    }
+  }
+
+  private async unloadPlugin(id: string): Promise<void> {
+    const plugin = this.plugins.get(id);
+    if (!plugin) return;
+
+    this.plugins.delete(id);
+    this.directoryIndex.delete(plugin.directory);
+    this.commandRegistry.removeAll(id);
+    for (const eventName of plugin.eventNames) {
+      const listeners = this.eventListeners.get(eventName);
+      listeners?.delete(id);
+      if (!listeners?.size) {
+        this.eventListeners.delete(eventName);
+      }
+      this.unsubscribeAppEvent(eventName);
+    }
+
+    this.settings.registerSchema(id, undefined);
+    this.ui.onSettingsSchema?.(id, undefined);
+
+    plugin.abortController.abort();
+
+    try {
+      if (typeof plugin.plugin.deactivate === "function") {
+        await withBudget(() => plugin.plugin.deactivate?.(), this.config.timeouts.deactivate);
+      }
+    } catch (error) {
+      plugin.runtime.logger.error("Plugin deactivate failed", error);
+    }
+
+    await disposeAll(plugin.activationDisposables);
+    plugin.activationDisposables.length = 0;
+
+    const contextDisposables = [...plugin.runtime.context.disposables];
+    plugin.runtime.context.disposables.length = 0;
+    await disposeAll(contextDisposables);
+
+    plugin.runtime.scheduler.dispose();
+    plugin.runtime.disposeEvents();
+
+    URL.revokeObjectURL(plugin.blobUrl);
+  }
+}
+
+export const createPluginHost = (config?: HostConfig): PluginHost => new KasetPluginHost(config);
+
+export type { RegisteredCommand } from "./host/ui-adapter";
+export type { ActivationEvent, CommandDefinition, Manifest, Permissions, JSONSchema } from "./model/manifest";
+export type { Disposable, Events, FSApi, Logger, PluginContext, Scheduler, SettingsApi, UIHostApi } from "./host/types";
+export { SettingsValidationError } from "./host/types";
+export { HOST_API_VERSION } from "./constants";

--- a/packages/@pstdio/kaset-plugin-host/src/model/manifest.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/model/manifest.ts
@@ -1,0 +1,41 @@
+export type Glob = string;
+
+export interface Permissions {
+  fs?: {
+    read?: Glob[];
+    write?: Glob[];
+  };
+  net?: string[];
+}
+
+export type ActivationEvent =
+  | { type: "onStartup" }
+  | { type: "onCommand"; id: string }
+  | { type: "onFSChange"; glob: Glob }
+  | { type: "onCron"; expr: string }
+  | { type: "onEvent"; name: string };
+
+export interface CommandDefinition {
+  id: string;
+  title: string;
+  category?: string;
+  when?: string;
+}
+
+export interface UICommands {
+  commands?: CommandDefinition[];
+}
+
+export type JSONSchema = Record<string, unknown>;
+
+export interface Manifest {
+  id: string;
+  name: string;
+  version: string;
+  api: string;
+  entry: string;
+  activation?: ActivationEvent[];
+  permissions?: Permissions;
+  ui?: UICommands;
+  settingsSchema?: JSONSchema;
+}

--- a/packages/@pstdio/kaset-plugin-host/src/model/plugin.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/model/plugin.ts
@@ -1,0 +1,13 @@
+import type { PluginContext } from "../host/types";
+
+export interface PluginModule {
+  default: Plugin;
+  commands?: Record<string, PluginCommand>;
+}
+
+export type PluginCommand = (ctx: PluginContext) => void | Promise<void>;
+
+export interface Plugin {
+  activate(ctx: PluginContext): Promise<void> | void;
+  deactivate?(): Promise<void> | void;
+}

--- a/packages/@pstdio/kaset-plugin-host/src/types/external.d.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/types/external.d.ts
@@ -1,0 +1,11 @@
+declare module "micromatch" {
+  export function isMatch(
+    str: string,
+    patterns: string | readonly string[],
+    options?: { dot?: boolean; nocase?: boolean },
+  ): boolean;
+}
+
+declare module "semver" {
+  export function satisfies(version: string, range: string): boolean;
+}

--- a/packages/@pstdio/kaset-plugin-host/src/utils/async.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/utils/async.ts
@@ -1,0 +1,64 @@
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+type MaybePromise<T> = T | Promise<T>;
+
+export const withBudget = async <T>(fn: () => MaybePromise<T>, budgetMs: number, signal?: AbortSignal): Promise<T> => {
+  if (budgetMs <= 0) {
+    return await fn();
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let abortHandler: (() => void) | undefined;
+  let aborted = false;
+
+  const timerPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new TimeoutError("Operation timed out"));
+    }, budgetMs);
+  });
+
+  const abortPromise = signal
+    ? new Promise<never>((_, reject) => {
+        if (signal.aborted) {
+          aborted = true;
+          reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+          return;
+        }
+        abortHandler = () => {
+          aborted = true;
+          reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+        };
+        signal.addEventListener("abort", abortHandler!, { once: true });
+      })
+    : undefined;
+
+  try {
+    const racers = [Promise.resolve(fn()), timerPromise];
+    if (abortPromise) racers.push(abortPromise);
+    const result = await Promise.race(racers as Promise<T>[]);
+    return result;
+  } catch (error) {
+    if (aborted && error == null) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+    throw error;
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (abortHandler && signal) {
+      signal.removeEventListener("abort", abortHandler);
+    }
+  }
+};
+
+export const sequential = async <T>(tasks: Array<() => MaybePromise<T>>): Promise<T[]> => {
+  const out: T[] = [];
+  for (const task of tasks) {
+    out.push(await task());
+  }
+  return out;
+};

--- a/packages/@pstdio/kaset-plugin-host/src/utils/dispose.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/utils/dispose.ts
@@ -1,0 +1,11 @@
+import type { Disposable } from "../host/types";
+
+export const disposeAll = async (disposables: Iterable<Disposable>): Promise<void> => {
+  for (const disposable of disposables) {
+    try {
+      await disposable.dispose();
+    } catch (error) {
+      console.error("[kaset-plugin-host] dispose failed", error);
+    }
+  }
+};

--- a/packages/@pstdio/kaset-plugin-host/src/utils/object.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/utils/object.ts
@@ -1,0 +1,9 @@
+export const clone = <T>(value: T): T => {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  if (value === undefined) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};

--- a/packages/@pstdio/kaset-plugin-host/src/utils/path.ts
+++ b/packages/@pstdio/kaset-plugin-host/src/utils/path.ts
@@ -1,0 +1,17 @@
+const split = (value: string) => value.split("/").filter(Boolean);
+
+export const joinPath = (...parts: Array<string | undefined>): string => {
+  const tokens: string[] = [];
+  for (const part of parts) {
+    if (!part) continue;
+    tokens.push(...split(part));
+  }
+  return tokens.join("/");
+};
+
+export const trimLeadingSlash = (value: string): string => value.replace(/^\/+/, "");
+
+export const ensureLeadingSlash = (value: string): string =>
+  value.startsWith("/") ? value : value ? `/${value}` : "/";
+
+export const withTrailingSlash = (value: string): string => (value.endsWith("/") ? value : `${value}/`);


### PR DESCRIPTION
## Summary
- add manifest, plugin, and host context types for the browser plugin host
- implement permission-checked plugin loading, command registry, activation wiring, and runtime utilities in the new kaset-plugin-host package
- integrate scheduler, settings manager, logging, and external module declarations while wiring build dependencies

## Testing
- npm run format:check
- npm run lint
- npx lerna run build
- npx lerna run test *(fails: @pstdio/opfs-utils expects Array.fromAsync available in Node 22)*

------
https://chatgpt.com/codex/tasks/task_e_68cad9fb5d8c83218c464f04ad0c66cc