### PR TITLE
feat(kas): omit reasoning when effort not set

### DIFF
--- a/packages/@pstdio/kas/src/agent.ts
+++ b/packages/@pstdio/kas/src/agent.ts
@@ -26,7 +26,7 @@ export function createKasAgent(opts: CreateKasAgentOptions) {
   const llm = createLLMTask({
     model: opts.model,
     apiKey: opts.apiKey,
-    reasoning: { effort: opts.effort ?? "low" },
+    ...(opts.effort ? { reasoning: { effort: opts.effort } } : {}),
     ...(opts.baseURL ? { baseUrl: opts.baseURL } : {}),
     dangerouslyAllowBrowser: opts.dangerouslyAllowBrowser ?? true,
   });


### PR DESCRIPTION
## Summary
- update the kas agent to only include reasoning configuration when an effort level is provided
- avoid sending the unsupported `reasoning_effort` argument for models that do not expect it

## Testing
- `CI=1 npm run format:check`
- `CI=1 npm run lint`
- `CI=1 npx lerna run build`
- `CI=1 npx lerna run test` *(fails: `@pstdio/opfs-utils:test` depends on `Array.fromAsync` which is unavailable in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd02021fe88321b41eba079ac06e36