### PR TITLE
Route conversation IDs as session IDs

### DIFF
--- a/clients/playground/src/components/ui/conversation-host.tsx
+++ b/clients/playground/src/components/ui/conversation-host.tsx
@@ -81,7 +81,7 @@ export function ConversationHost() {
 
     try {
       setStreaming(true);
-      for await (const updated of sendMessage(base)) {
+      for await (const updated of sendMessage(conversationId, base)) {
         if (!conversationId) continue;
         useWorkspaceStore.setState(
           (state) => {

--- a/clients/playground/src/services/ai/sendMessage.ts
+++ b/clients/playground/src/services/ai/sendMessage.ts
@@ -5,9 +5,11 @@ import { buildInitialConversation, createKasAgent, toConversation } from "@pstdi
 import { safeAutoCommit } from "@pstdio/opfs-utils";
 import { requestApproval } from "./approval";
 
-export async function* sendMessage(conversation: UIConversation) {
+export async function* sendMessage(conversationId: string, conversation: UIConversation) {
   const projectId = useWorkspaceStore.getState().selectedProjectId;
   const dir = `/${PROJECTS_ROOT}/${projectId}`;
+
+  const sessionId = conversationId;
 
   const { initialForAgent, uiBoot, devNote } = await buildInitialConversation(conversation, dir);
 
@@ -25,7 +27,7 @@ export async function* sendMessage(conversation: UIConversation) {
     requestApproval,
   });
 
-  for await (const ui of toConversation(agent(initialForAgent), { boot: uiBoot, devNote })) {
+  for await (const ui of toConversation(agent(initialForAgent, { sessionId }), { boot: uiBoot, devNote })) {
     yield ui;
   }
 

--- a/packages/@pstdio/tiny-ai-tasks/src/llm/createLLMTask.ts
+++ b/packages/@pstdio/tiny-ai-tasks/src/llm/createLLMTask.ts
@@ -33,10 +33,11 @@ export function createLLMTask(opts: LLMTaskOptions) {
   return task(
     "llm_chat",
     async function* (
-      input: BaseMessage[] | { messages: BaseMessage[]; tools?: Array<Tool<any, any>> },
+      input: BaseMessage[] | { messages: BaseMessage[]; tools?: Array<Tool<any, any>>; sessionId?: string },
     ): AsyncGenerator<AssistantMessage, AssistantMessage, unknown> {
       const messages = Array.isArray(input) ? input : input.messages;
       const callTools = Array.isArray(input) ? [] : (input.tools ?? []);
+      const sessionId = Array.isArray(input) ? undefined : input.sessionId;
 
       const toolDefs: ChatCompletionTool[] = [...toOpenAITools(tools ?? []), ...toOpenAITools(callTools)];
 
@@ -52,6 +53,7 @@ export function createLLMTask(opts: LLMTaskOptions) {
         ...(temperature !== undefined ? { temperature } : {}),
         ...(reasoning ? { reasoning_effort: reasoning.effort } : {}),
         ...(toolDefs.length ? { tools: toolDefs } : {}),
+        ...(sessionId ? { session_id: sessionId } : {}),
       });
 
       const assistant: AssistantMessage = { role: "assistant", content: "" };


### PR DESCRIPTION
## Summary
- remove stored session identifiers from playground conversations and derive the OpenAI session id directly from each conversation id when streaming replies
- allow Kas agents to receive a per-run session id by passing it through the agent invocation, and forward that value through createAgent to the LLM task
- update the LLM task to accept the session id on each call (plus tests) so OpenAI requests are tagged without modifying agent construction

## Testing
- npm run format:check
- npm run lint
- npx lerna run build
- npx lerna run test *(fails: @pstdio/opfs-utils tests expect Array.fromAsync, which is unavailable in this Node runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6558db608321a52905e274bc6dd8