### PR TITLE
Ensure playground windows stay within desktop bounds

### DIFF
--- a/clients/playground-new/public/sw.js
+++ b/clients/playground-new/public/sw.js
@@ -35,22 +35,22 @@ r.addEventListener("activate", (t) => {
 r.addEventListener("fetch", (t) => {
   const e = t,
     { request: a } = e;
-  d(a) &&
-    e.respondWith(
-      (async () => {
-        const s = await caches.open(l),
-          n = await f(s, a);
-        if (n) return n;
-        if (new URL(a.url).pathname === c)
-          try {
-            const i = await fetch(a);
-            return (i && i.ok && (await s.put(c, i.clone())), i);
-          } catch (i) {
-            return (console.error("SW runtime fetch failed:", i), new Response("Runtime unavailable", { status: 503 }));
-          }
-        return new Response("Not found", { status: 404 });
-      })(),
-    );
+  if (!d(a)) return;
+  e.respondWith(
+    (async () => {
+      const s = await caches.open(l),
+        n = await f(s, a);
+      if (n) return n;
+      if (new URL(a.url).pathname === c)
+        try {
+          const i = await fetch(a);
+          return (i && i.ok && (await s.put(c, i.clone())), i);
+        } catch (i) {
+          return (console.error("SW runtime fetch failed:", i), new Response("Runtime unavailable", { status: 503 }));
+        }
+      return new Response("Not found", { status: 404 });
+    })(),
+  );
 });
 r.addEventListener("error", (t) => {
   console.error("SW error:", t.message, t.filename, t.lineno, t.colno, t.error);


### PR DESCRIPTION
## Summary
- constrain playground desktop windows to the container width and height and clamp their positions when dragging or resizing
- set dynamic min/max dimensions based on the desktop size so windows never extend beyond the desktop
- adjust the service worker fetch handler guard to satisfy lint rules

## Testing
- npm run lint --workspace playground-new

------
https://chatgpt.com/codex/tasks/task_e_68e599caa06883219125d040e4ffca11