### PR TITLE
Ensure playground reset removes empty directories

### DIFF
--- a/clients/playground-new/src/services/playground/reset.ts
+++ b/clients/playground-new/src/services/playground/reset.ts
@@ -1,5 +1,5 @@
 import { ROOT } from "@/constant";
-import { deleteFile, ls } from "@pstdio/opfs-utils";
+import { deleteDirectoryContents, ls } from "@pstdio/opfs-utils";
 
 import { setupPlayground } from "./setup";
 
@@ -14,23 +14,22 @@ export async function resetPlayground(options: ResetOptions = {}) {
   let deleted = 0;
 
   try {
-    const files = await ls(normalizedRoot, {
+    const entries = await ls(normalizedRoot, {
       maxDepth: Infinity,
-      kinds: ["file"],
+      kinds: ["file", "directory"],
       showHidden: true,
       sortBy: "path",
     });
 
-    for (const entry of files) {
-      try {
-        await deleteFile(`${normalizedRoot}/${entry.path}`);
-        deleted++;
-      } catch (error) {
-        console.warn(`Failed to delete ${entry.path} during reset`, error);
-      }
-    }
+    deleted = entries.length;
   } catch (error) {
-    console.warn(`Failed to enumerate files for reset at ${normalizedRoot}`, error);
+    console.warn(`Failed to enumerate entries for reset at ${normalizedRoot}`, error);
+  }
+
+  try {
+    await deleteDirectoryContents(normalizedRoot);
+  } catch (error) {
+    console.warn(`Failed to delete contents during reset at ${normalizedRoot}`, error);
   }
 
   const setupResult = await setupPlayground({ rootDir: normalizedRoot, overwrite: true });

--- a/packages/@pstdio/opfs-utils/src/index.ts
+++ b/packages/@pstdio/opfs-utils/src/index.ts
@@ -33,7 +33,7 @@ export { ensureDirExists, getDirectoryHandle, stripAnsi } from "./shared";
 export { runOpfsCommandLine } from "./shell/opfs-shell";
 export { createJsonFileStorage, type JsonFileStorage, type JsonFileStorageOptions } from "./state/json-storage";
 export { bindStoreToJsonFile, type BindStoreOptions, type StoreAdapter } from "./state/store-binding";
-export { deleteFile, downloadFile, moveFile, readFile, writeFile } from "./utils/opfs-crud";
+export { deleteDirectoryContents, deleteFile, downloadFile, moveFile, readFile, writeFile } from "./utils/opfs-crud";
 export { createScopedFs, type ScopedFs } from "./adapter/scoped-fs";
 export {
   DEFAULT_MAX_LINES_TEXT_FILE,


### PR DESCRIPTION
## Summary
- add a new `deleteDirectoryContents` helper in `@pstdio/opfs-utils` to recursively clear directories
- update the playground reset routine to use the recursive deletion helper so empty folders are removed
- cover the new helper with tests verifying nested files and directories are cleared

## Testing
- `npm run test --workspace @pstdio/opfs-utils` *(fails: environment lacks Array.fromAsync used by zenfs)*
- `npx vitest run packages/@pstdio/opfs-utils/src/utils/opfs-crud.test.ts` *(fails: environment lacks Array.fromAsync used by zenfs)*

------
https://chatgpt.com/codex/tasks/task_e_68e6587592b48321a60736a9be03a957