### PR TITLE
feat: add responsive layout to playground-new

### DIFF
--- a/clients/playground-new/src/App.tsx
+++ b/clients/playground-new/src/App.tsx
@@ -1,6 +1,6 @@
-import { Box, Flex, useBreakpointValue } from "@chakra-ui/react";
+import { Box, Button, Flex, useBreakpointValue } from "@chakra-ui/react";
 import { Allotment } from "allotment";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ConversationHost } from "./components/ui/conversation-host";
 import { Desktop } from "./components/ui/desktop";
 import { GithubCorner } from "./components/ui/github-corner";
@@ -10,26 +10,64 @@ import { setupPlayground } from "./services/playground/setup";
 
 export function App() {
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
+  const [mobilePane, setMobilePane] = useState<"conversation" | "desktop">("conversation");
 
   useEffect(() => {
     setupPlayground();
   }, []);
 
+  useEffect(() => {
+    if (!isMobile) {
+      setMobilePane("conversation");
+    }
+  }, [isMobile]);
+
+  const handleMobileToggle = () => {
+    setMobilePane((current) => (current === "conversation" ? "desktop" : "conversation"));
+  };
+
+  const mobileToggleButton = !isMobile
+    ? undefined
+    : (
+        <Button size="sm" variant="outline" onClick={handleMobileToggle} minWidth="140px">
+          {mobilePane === "conversation" ? "Show Desktop" : "Show Chat"}
+        </Button>
+      );
+
+  const conversationPane = (
+    <Flex direction="column" height="100%" padding="3" gap="3" flex="1" width="100%">
+      <TopBar mobileCenterContent={mobileToggleButton} />
+      <Box flex="1" overflow="hidden" borderWidth="1px" borderRadius="md">
+        <ConversationHost />
+      </Box>
+    </Flex>
+  );
+
+  const desktopPane = isMobile ? (
+    <Flex direction="column" height="100%" padding="3" gap="3" flex="1" width="100%">
+      <TopBar mobileCenterContent={mobileToggleButton} />
+      <Box flex="1" overflow="hidden" borderWidth="1px" borderRadius="md" height="100%">
+        <Desktop />
+      </Box>
+    </Flex>
+  ) : (
+    <Desktop />
+  );
+
+  const layout = isMobile ? (
+    mobilePane === "conversation" ? conversationPane : desktopPane
+  ) : (
+    <Allotment>
+      <Allotment.Pane minSize={260} preferredSize={420} maxSize={580}>
+        {conversationPane}
+      </Allotment.Pane>
+      <Allotment.Pane minSize={360}>{desktopPane}</Allotment.Pane>
+    </Allotment>
+  );
+
   return (
-    <Flex direction="row" height="100vh" width="100vw">
-      <Allotment>
-        <Allotment.Pane minSize={260} preferredSize={420} maxSize={580}>
-          <Flex direction="column" height="100%" padding="3" gap="3" flex="1" width="100%">
-            <TopBar />
-            <Box flex="1" overflow="hidden" borderWidth="1px" borderRadius="md">
-              <ConversationHost />
-            </Box>
-          </Flex>
-        </Allotment.Pane>
-        <Allotment.Pane minSize={360}>
-          <Desktop />
-        </Allotment.Pane>
-      </Allotment>
+    <Flex direction={isMobile ? "column" : "row"} height="100vh" width="100vw">
+      {layout}
 
       {!isMobile && <GithubCorner href="https://github.com/pufflyai/kaset" />}
 


### PR DESCRIPTION
## Summary
- add a mobile pane toggle that switches between the conversation view and the desktop workspace
- reuse the top bar as a mobile navigation surface and wrap panes so they size correctly on phones
- reset the mobile view back to the chat when returning to wider screens for consistency

## Testing
- Not run (Vite dev server fails to resolve internal @pstdio packages in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e66c78f6e48321b7ce2b34b4c049df