### PR TITLE
Fix tiny-ui asset URLs for playground service worker

### DIFF
--- a/clients/playground-new/src/services/plugins/tiny-ui-window.tsx
+++ b/clients/playground-new/src/services/plugins/tiny-ui-window.tsx
@@ -26,8 +26,15 @@ export interface PluginTinyUiWindowProps {
   pluginWindow: PluginDesktopWindowDescriptor;
 }
 
-const serviceWorkerUrl = `${import.meta.env.BASE_URL}sw.js`;
-const runtimeUrl = `${import.meta.env.BASE_URL}tiny-ui/runtime.html`;
+const buildAssetUrl = (path: string) => {
+  const baseUrl = import.meta.env.BASE_URL || "/";
+  const normalizedBase = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
+  return `${normalizedBase}${normalizedPath}`;
+};
+
+const serviceWorkerUrl = buildAssetUrl("sw.js");
+const runtimeUrl = buildAssetUrl("tiny-ui/runtime.html");
 
 const buildPluginRoot = (pluginsRoot: string, pluginId: string) => {
   const normalized = pluginsRoot.replace(/\/+$/, "");


### PR DESCRIPTION
## Summary
- normalize how the playground tiny-ui window builds asset URLs to ensure trailing slashes are preserved
- fix service worker and runtime URL generation so deployments under subpaths load without installation errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e836e3a7188321a6519adc56fd1863