### PR TITLE
feat(opfs-utils): add patch performance storybook benchmark

### DIFF
--- a/clients/playground-new/src/example-files/agents.md
+++ b/clients/playground-new/src/example-files/agents.md
@@ -4,12 +4,19 @@ The user has a **demo desktop website** they can expand by _vibecoding_ plugins 
 
 - Assume the user is not technical, avoid technical jargon.
 
-## Core Actions
+## What you can see and edit
 
-### What you can see and edit
+### `plugins` folder
 
-- Plugin folders live under `/plugins/<pluginId>/`.
+- Plugins live under `/plugins/<pluginId>/`.
 - Each must contain a `manifest.json` that defines metadata, entry module, and optional settings.
+
+### `plugin_data` folder
+
+- Use for long-lived plugin data such as serialized state, user-created documents, cached API responses, or generated assets.
+- Persistent files live under `/plugin_data/`.
+- Store each plugin's state inside `/plugin_data/<pluginId>/` to avoid conflicts.
+- Conventionally include files like `state.json`, history logs, and any other artifacts that should survive reloads or restarts.
 
 ### Manifests
 

--- a/clients/playground-new/src/state/defaultState.ts
+++ b/clients/playground-new/src/state/defaultState.ts
@@ -23,5 +23,6 @@ export const DEFAULT_STATE: WorkspaceState = {
     mcpServers: [],
     activeMcpServerIds: [],
     theme: "light" satisfies ThemePreference,
+    wallpaper: "kaset.png",
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24777,6 +24777,7 @@
         "playwright": "^1.54.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-scan": "^0.4.3",
         "storybook": "^9.1.2",
         "storybook-addon-vis": "^2.1.2",
         "vite": "^7.1.0",

--- a/packages/@pstdio/opfs-utils/package.json
+++ b/packages/@pstdio/opfs-utils/package.json
@@ -61,6 +61,7 @@
     "playwright": "^1.54.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-scan": "^0.4.3",
     "storybook": "^9.1.2",
     "storybook-addon-vis": "^2.1.2",
     "vite": "^7.1.0",

--- a/packages/@pstdio/opfs-utils/playground/PatchPerformance.stories.tsx
+++ b/packages/@pstdio/opfs-utils/playground/PatchPerformance.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { createTwoFilesPatch } from "diff";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { scan, setOptions } from "react-scan";
 import type { ApplyPatchOptions, FileOperationResult } from "../src/git/patch";
 import { applyPatchInOPFS } from "../src/git/patch";
 import { getFs } from "../src/adapter/fs";
@@ -55,6 +56,12 @@ const meta: Meta = {
 export default meta;
 
 type Story = StoryObj;
+
+declare global {
+  interface Window {
+    __opfsBenchmarkScanInitialized?: boolean;
+  }
+}
 
 const SYNTHETIC_PARAGRAPH =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. " +
@@ -190,6 +197,25 @@ function PatchPerformanceStory() {
   const [status, setStatus] = useState<string>("Idle");
   const [running, setRunning] = useState(false);
   const [results, setResults] = useState<ScenarioRunResult[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const options = {
+      allowInIframe: true,
+      enabled: true,
+      showFPS: true,
+      showToolbar: true,
+    };
+
+    if (!window.__opfsBenchmarkScanInitialized) {
+      window.__opfsBenchmarkScanInitialized = true;
+      scan(options);
+      return;
+    }
+
+    setOptions(options);
+  }, []);
 
   useEffect(() => {
     let mounted = true;


### PR DESCRIPTION
## Summary
- add a Storybook benchmark story that warms the OPFS adapter and runs patch scenarios against demo data
- cover small modifications, multi-file patches, rename-only changes, and synthetic large README updates with diff metrics
- surface per-scenario timing stats, diff sizing, and iteration logs in the Storybook UI for quick benchmarking

## Testing
- npm run format
- CI=1 npm run lint
- CI=1 npm run build
- CI=1 npm run test *(fails: Array.fromAsync is not a function in node-based vitest runs)*

------
https://chatgpt.com/codex/tasks/task_e_68eaef2becfc83218365ca44a27f867f