### PR TITLE
Add setting to hide React Scan overlay

### DIFF
--- a/clients/playground-new/src/components/ui/settings-modal.tsx
+++ b/clients/playground-new/src/components/ui/settings-modal.tsx
@@ -84,6 +84,7 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
   const [wallpapers, setWallpapers] = useState<string[]>([]);
   const [selectedWallpaper, setSelectedWallpaper] = useState<string>("");
   const [wallpaperPreviews, setWallpaperPreviews] = useState<Record<string, string>>({});
+  const [hideReactScan, setHideReactScan] = useState(false);
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
 
   useEffect(() => {
@@ -100,6 +101,7 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
     setInitialTheme(nextTheme);
 
     setSelectedWallpaper(settings.wallpaper ?? DEFAULT_WALLPAPER);
+    setHideReactScan(settings.hideReactScan ?? false);
 
     const storedServers = settings.mcpServers;
     const effectiveServers = storedServers ?? [];
@@ -332,6 +334,22 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
                 })}
               </SimpleGrid>
             </Field.Root>
+            <Field.Root>
+              <Field.Label>Developer Tools</Field.Label>
+              <VStack align="stretch" gap="xs">
+                <Checkbox.Root
+                  checked={hideReactScan}
+                  onCheckedChange={(event) => setHideReactScan(event.checked === true)}
+                >
+                  <Checkbox.HiddenInput />
+                  <Checkbox.Control />
+                  <Checkbox.Label>Hide React Scan overlay</Checkbox.Label>
+                </Checkbox.Root>
+                <Text fontSize="sm" color="fg.muted">
+                  Disable the React Scan developer overlay for a distraction-free workspace.
+                </Text>
+              </VStack>
+            </Field.Root>
           </VStack>
         );
       case "permissions":
@@ -482,6 +500,7 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
         activeMcpServerIds: nextActiveIds,
         theme,
         wallpaper: selectedWallpaper || undefined,
+        hideReactScan,
       });
 
       setInitialTheme(theme);

--- a/clients/playground-new/src/services/react-scan/init.ts
+++ b/clients/playground-new/src/services/react-scan/init.ts
@@ -1,5 +1,56 @@
-import { scan } from "react-scan";
+import { useWorkspaceStore } from "@/state/WorkspaceProvider";
+import type { WorkspaceState } from "@/state/types";
+import { scan, setOptions } from "react-scan";
 
-scan({
-  enabled: true,
-});
+const WORKSPACE_STORAGE_KEY = "kaset-workspace";
+
+const getPersistedHideReactScan = () => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return false;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_STORAGE_KEY);
+    if (!raw) return false;
+
+    const parsed = JSON.parse(raw) as { state?: WorkspaceState } | undefined;
+    return parsed?.state?.settings?.hideReactScan ?? false;
+  } catch (error) {
+    console.warn("Failed to read React Scan setting from storage:", error);
+    return false;
+  }
+};
+
+const initializeReactScan = () => {
+  if (typeof window === "undefined") return;
+
+  const hideReactScan = getPersistedHideReactScan();
+  scan({
+    enabled: !hideReactScan,
+  });
+
+  const subscribeToWorkspaceStore = () => {
+    if (!useWorkspaceStore) {
+      window.requestAnimationFrame(subscribeToWorkspaceStore);
+      return;
+    }
+
+    const currentHide = useWorkspaceStore.getState().settings.hideReactScan ?? false;
+    if (currentHide !== hideReactScan) {
+      setOptions({ enabled: !currentHide });
+    }
+
+    let previousHide = currentHide;
+
+    useWorkspaceStore.subscribe((state) => {
+      const nextHide = state.settings.hideReactScan ?? false;
+      if (nextHide === previousHide) return;
+      previousHide = nextHide;
+      setOptions({ enabled: !nextHide });
+    });
+  };
+
+  subscribeToWorkspaceStore();
+};
+
+initializeReactScan();

--- a/clients/playground-new/src/state/actions/saveWorkspaceSettings.ts
+++ b/clients/playground-new/src/state/actions/saveWorkspaceSettings.ts
@@ -13,6 +13,7 @@ export const saveWorkspaceSettings = (settings: WorkspaceSettings, actionName = 
         settings.activeMcpServerIds && settings.activeMcpServerIds.length > 0 ? [...settings.activeMcpServerIds] : [];
       state.settings.theme = settings.theme ?? "light";
       state.settings.wallpaper = settings.wallpaper || undefined;
+      state.settings.hideReactScan = settings.hideReactScan ?? false;
 
       if ((state as Record<string, unknown>).selectedMcpServerId) {
         delete (state as Record<string, unknown>).selectedMcpServerId;

--- a/clients/playground-new/src/state/defaultState.ts
+++ b/clients/playground-new/src/state/defaultState.ts
@@ -23,5 +23,6 @@ export const DEFAULT_STATE: WorkspaceState = {
     mcpServers: [],
     activeMcpServerIds: [],
     theme: "light" satisfies ThemePreference,
+    hideReactScan: false,
   },
 };

--- a/clients/playground-new/src/state/types.ts
+++ b/clients/playground-new/src/state/types.ts
@@ -75,6 +75,7 @@ export interface WorkspaceSettings {
   activeMcpServerIds?: string[];
   theme?: ThemePreference;
   wallpaper?: string;
+  hideReactScan?: boolean;
 }
 
 export interface WorkspaceState {


### PR DESCRIPTION
## Summary
- add a "Hide React Scan overlay" toggle to the display settings and persist it with workspace preferences
- initialize React Scan according to the saved preference and update the overlay when the setting changes

## Testing
- npm run format
- npm run lint
- CI=1 npm run build --workspace clients/playground-new
- npm run test *(fails: Array.fromAsync is not a function in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecca7d08e88321a11008dc36dfb44f