### PR TITLE
Apply manifest defaults when reading plugin settings

### DIFF
--- a/packages/@pstdio/tiny-plugins/src/host/host.ts
+++ b/packages/@pstdio/tiny-plugins/src/host/host.ts
@@ -61,7 +61,7 @@ export function createPluginHost(options: HostOptions = {}): PluginHost {
     command: options.timeouts?.command ?? DEFAULT_TIMEOUTS.command,
   };
 
-  const ajv = new Ajv({ allErrors: true });
+  const ajv = new Ajv({ allErrors: true, useDefaults: true });
 
   const manifestValidator = ajv.compile(manifestSchema) as ValidateFunction;
 

--- a/packages/@pstdio/tiny-plugins/src/host/settings.test.ts
+++ b/packages/@pstdio/tiny-plugins/src/host/settings.test.ts
@@ -1,0 +1,30 @@
+import Ajv from "ajv";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ScopedFs } from "@pstdio/opfs-utils";
+
+import { createSettingsAccessor } from "./settings";
+
+describe("createSettingsAccessor", () => {
+  it("applies schema defaults when the settings file is missing", async () => {
+    const missingError = Object.assign(new Error("missing"), { code: "ENOENT" });
+    const fs = {
+      readJSON: vi.fn().mockRejectedValue(missingError),
+      writeJSON: vi.fn(),
+    } as unknown as ScopedFs;
+
+    const ajv = new Ajv({ allErrors: true, useDefaults: true });
+    const validator = ajv.compile({
+      type: "object",
+      properties: {
+        theme: { type: "string", default: "light" },
+      },
+      required: ["theme"],
+    });
+
+    const settings = createSettingsAccessor(fs, "plugin.test", validator);
+
+    await expect(settings.read<{ theme: string }>()).resolves.toEqual({ theme: "light" });
+    expect(fs.readJSON).toHaveBeenCalledWith(".settings.json");
+  });
+});


### PR DESCRIPTION
## Summary
- instantiate Ajv with default materialization in the plugin host so schema defaults are populated
- validate settings during reads to apply manifest defaults and surface invalid data
- add coverage ensuring settings reads return schema defaults when the file is absent

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test
- npm run test --workspace @pstdio/tiny-plugins


------
https://chatgpt.com/codex/tasks/task_e_68edf537e21083219c3b71f54bd1892b