### PR TITLE
feat(playground-new): seed todo plugin data and update storage path

### DIFF
--- a/clients/playground-new/src/example-files/agents.md
+++ b/clients/playground-new/src/example-files/agents.md
@@ -127,8 +127,8 @@ export function mount(container) {
 
 You operate on Markdown files that represent todo lists.
 
-- All todo lists live under the `plugin_data/todo/todos/` folder.
-- Each list is a separate file named `plugin_data/todo/todos/<list_name>.md`.
+- All todo lists live under the `plugin_data/todo/` folder.
+- Each list is a separate file named `plugin_data/todo/<list_name>.md`.
 - The user refers to lists by `<list_name>` (no `.md`).
 - If no list is specified, use the most relevant one or create a new one.
 - You may update `state.json` to record the currently active list.

--- a/clients/playground-new/src/example-plugin-data/todo/shopping.md
+++ b/clients/playground-new/src/example-plugin-data/todo/shopping.md
@@ -1,0 +1,5 @@
+- [ ] A unicorn
+- [ ] One minute of yesterday
+- [ ] A piece of genuine Atlantis
+- [ ] Moonlight in a bottle
+- [ ] A live dragon

--- a/clients/playground-new/src/example-plugins/todo/src/state/createStore.ts
+++ b/clients/playground-new/src/example-plugins/todo/src/state/createStore.ts
@@ -5,7 +5,7 @@ import { immer } from "zustand/middleware/immer";
 import type { TodoItem, TodoStore } from "./types";
 
 export const ROOT = "playground";
-export const TODO_LISTS_DIR = `${ROOT}/plugin_data/todo/todos`;
+export const TODO_LISTS_DIR = `${ROOT}/plugin_data/todo`;
 
 function parseMarkdownTodos(md: string): TodoItem[] {
   const lines = md.split("\n");

--- a/clients/playground-new/src/services/playground/reset.ts
+++ b/clients/playground-new/src/services/playground/reset.ts
@@ -40,5 +40,6 @@ export async function resetPlayground(options: ResetOptions = {}) {
     written: setupResult.written,
     rootFiles: setupResult.rootFiles,
     pluginFiles: setupResult.pluginFiles,
+    pluginDataFiles: setupResult.pluginDataFiles,
   };
 }

--- a/clients/playground-new/src/services/playground/setup.ts
+++ b/clients/playground-new/src/services/playground/setup.ts
@@ -33,6 +33,12 @@ const EXAMPLE_PLUGIN_BUNDLE = import.meta.glob("/src/example-plugins/**", {
   eager: true,
 }) as Record<string, string>;
 
+const EXAMPLE_PLUGIN_DATA_BUNDLE = import.meta.glob("/src/example-plugin-data/**", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
 const WALLPAPER_BUNDLE = import.meta.glob("/src/example-files/wallpaper/*.{png,jpg,jpeg,gif,webp}", {
   query: "?url",
   import: "default",
@@ -149,10 +155,12 @@ export async function setupPlayground(options: SetupOptions = {}) {
 
   const normalizedRoot = normalizeOpfsPath(rootDir);
   const pluginsRoot = `${normalizedRoot}/plugins`;
+  const pluginDataRoot = `${normalizedRoot}/plugin_data`;
   const wallpaperRoot = `${normalizedRoot}/wallpaper`;
 
   await ensureDirectory(normalizedRoot);
   await ensureDirectory(pluginsRoot);
+  await ensureDirectory(pluginDataRoot);
   await ensureDirectory(wallpaperRoot);
 
   const rootFilesWritten = await applyBundle({
@@ -166,6 +174,13 @@ export async function setupPlayground(options: SetupOptions = {}) {
     bundleRoot: pluginsRoot,
     files: EXAMPLE_PLUGIN_BUNDLE,
     baseDir: "/src/example-plugins",
+    overwrite,
+  });
+
+  const pluginDataFilesWritten = await applyBundle({
+    bundleRoot: pluginDataRoot,
+    files: EXAMPLE_PLUGIN_DATA_BUNDLE,
+    baseDir: "/src/example-plugin-data",
     overwrite,
   });
 
@@ -206,9 +221,10 @@ export async function setupPlayground(options: SetupOptions = {}) {
 
   return {
     rootDir: normalizedRoot,
-    written: rootFilesWritten + pluginFilesWritten + wallpaperFilesWritten,
+    written: rootFilesWritten + pluginFilesWritten + pluginDataFilesWritten + wallpaperFilesWritten,
     rootFiles: rootFilesWritten,
     pluginFiles: pluginFilesWritten,
+    pluginDataFiles: pluginDataFilesWritten,
     wallpaperFiles: wallpaperFilesWritten,
   };
 }


### PR DESCRIPTION
## Summary
- add an example plugin-data bundle with a seeded todo shopping list
- load plugin-data during playground setup and expose the write counts
- point the todo plugin and documentation to plugin_data/todo instead of the nested folder

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: Array.fromAsync is not a function in @pstdio/opfs-utils tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ee02c8bff48321b9248452402f79d1