### PR TITLE
Fix desktop context menu trigger to avoid nested buttons

### DIFF
--- a/clients/playground-new/src/components/ui/desktop.tsx
+++ b/clients/playground-new/src/components/ui/desktop.tsx
@@ -649,7 +649,7 @@ export const Desktop = () => {
 
           return (
             <Menu.Root key={app.id}>
-              <Menu.ContextTrigger>
+              <Menu.ContextTrigger asChild>
                 <DesktopIcon
                   icon={app.icon}
                   label={app.title}


### PR DESCRIPTION
## Summary
- wrap the desktop app icon with `Menu.ContextTrigger` using `asChild` so the context menu no longer introduces a nested `<button>` element

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: @pstdio/opfs-utils vitest suite requires Array.fromAsync which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee56840f1883219e7953f72cdd9383