### PR TITLE
Refine desktop state tool

### DIFF
--- a/clients/playground-new/src/services/ai/sendMessage.ts
+++ b/clients/playground-new/src/services/ai/sendMessage.ts
@@ -5,6 +5,7 @@ import { buildInitialConversation, createKasAgent, toConversation } from "@pstdi
 import { safeAutoCommit } from "@pstdio/opfs-utils";
 import type { Tool } from "@pstdio/tiny-ai-tasks";
 import { requestApproval } from "./approval";
+import { checkDesktopStateTool } from "../desktop/checkDesktopStateTool";
 
 const directory = ROOT;
 
@@ -15,6 +16,8 @@ export async function* sendMessage(conversationId: string, conversation: UIConve
 
   const { modelId, approvalGatedTools, apiKey, baseUrl } = getWorkspaceSettings();
 
+  const toolsForAgent = [checkDesktopStateTool, ...extraTools];
+
   const agent = createKasAgent({
     model: modelId,
     workspaceDir: directory,
@@ -22,7 +25,7 @@ export async function* sendMessage(conversationId: string, conversation: UIConve
     requestApproval,
     apiKey: apiKey ?? "PLACEHOLDER_KEY",
     ...(baseUrl ? { baseURL: baseUrl } : {}),
-    extraTools: extraTools.length > 0 ? extraTools : undefined,
+    extraTools: toolsForAgent,
   });
 
   for await (const ui of toConversation(agent(initialForAgent, { sessionId }), { boot: uiBoot, devNote })) {

--- a/clients/playground-new/src/services/desktop/checkDesktopStateTool.ts
+++ b/clients/playground-new/src/services/desktop/checkDesktopStateTool.ts
@@ -1,0 +1,53 @@
+import { useWorkspaceStore } from "@/state/WorkspaceProvider";
+import type { DesktopWindow } from "@/state/types";
+import type { Tool } from "@pstdio/tiny-ai-tasks";
+
+type DesktopWindowState = "normal" | "minimized" | "maximized";
+
+export interface DesktopWindowSummary {
+  id: string;
+  appId: string;
+  title: string;
+  position: { x: number; y: number };
+  size: { width: number; height: number };
+  zIndex: number;
+  state: DesktopWindowState;
+  snapSide: DesktopWindow["snapSide"] | null;
+  openedAt: number;
+}
+
+function getWindowState(window: DesktopWindow): DesktopWindowState {
+  if (window.isMinimized) return "minimized";
+  if (window.isMaximized) return "maximized";
+  return "normal";
+}
+
+function toWindowSummary(window: DesktopWindow): DesktopWindowSummary {
+  return {
+    id: window.id,
+    appId: window.appId,
+    title: window.title,
+    position: { ...window.position },
+    size: { ...window.size },
+    zIndex: window.zIndex,
+    state: getWindowState(window),
+    snapSide: window.snapSide ?? null,
+    openedAt: window.openedAt,
+  };
+}
+
+export const checkDesktopStateTool: Tool<unknown, DesktopWindowSummary[]> = {
+  definition: {
+    name: "check_desktop_state",
+    description: "Return a snapshot of the open desktop windows, including geometry and state.",
+    parameters: {
+      type: "object",
+      properties: {},
+    },
+  },
+  async run() {
+    const { desktop } = useWorkspaceStore.getState();
+
+    return desktop.windows.map(toWindowSummary);
+  },
+};


### PR DESCRIPTION
## Summary
- move the `check_desktop_state` tool into the desktop service so it can return user-friendly window summaries
- expose each open window with id, title, position, size, z-order, and state information instead of raw store snapshots
- register the desktop state tool from the AI service so Kas still auto-loads it alongside any extra tools

## Testing
- npm run format
- CI=1 npm run lint
- CI=1 npm run build
- CI=1 npm run test *(fails: Array.fromAsync is not a function in @pstdio/opfs-utils)*

------
https://chatgpt.com/codex/tasks/task_e_68eed6cf195883219c583a800d060256