### PR TITLE
feat: use host APIs for tiny ui plugins

### DIFF
--- a/clients/playground-new/package.json
+++ b/clients/playground-new/package.json
@@ -9,6 +9,7 @@
     "build": "npm run typegen:tokens && tsc -b && vite build",
     "typegen:tokens": "chakra typegen ./src/theme/theme.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run",
     "preview": "vite preview",
     "format": "prettier --check \"./src/**/*.{js,jsx,ts,tsx,css,scss,html,md}\" --write",
     "visualize-bundle": "npx vite-bundle-visualizer"
@@ -61,7 +62,8 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.0",
     "vite": "^7.1.0",
-    "vite-plugin-svgr": "^4.3.0"
+    "vite-plugin-svgr": "^4.3.0",
+    "vitest": "^2.1.8"
   },
   "volta": {
     "node": "22.18.0"

--- a/clients/playground-new/src/example-plugins/file-explorer/src/components/file-explorer.tsx
+++ b/clients/playground-new/src/example-plugins/file-explorer/src/components/file-explorer.tsx
@@ -1,9 +1,10 @@
 import { Box, Breadcrumb, Flex, Text } from "@chakra-ui/react";
 import { FileText, FolderClosed } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { useFsTree, type FsNode } from "../hooks/fs";
+import { useFsTree, type FsNode, type WorkspaceHost } from "../hooks/fs";
 
 interface FileExplorerProps {
+  host: WorkspaceHost | null;
   rootDir: string;
   requestedPath?: string | null;
   onOpenFile?: (path: string, options?: { displayName?: string }) => Promise<void> | void;
@@ -40,8 +41,8 @@ const createBreadcrumbs = (currentId: string, maps: ReturnType<typeof buildMaps>
 };
 
 export function FileExplorer(props: FileExplorerProps) {
-  const { rootDir, onOpenFile, requestedPath } = props;
-  const fsTree = useFsTree(rootDir);
+  const { host, rootDir, onOpenFile, requestedPath } = props;
+  const fsTree = useFsTree(host, rootDir);
 
   const maps = useMemo(() => buildMaps(fsTree), [fsTree]);
   const [currentPath, setCurrentPath] = useState<string>(fsTree.id);

--- a/clients/playground-new/src/example-plugins/todo/src/state/TodoProvider.tsx
+++ b/clients/playground-new/src/example-plugins/todo/src/state/TodoProvider.tsx
@@ -1,25 +1,44 @@
 import { createContext, useRef } from "react";
 import type { PropsWithChildren } from "react";
 import type { StoreApi, UseBoundStore } from "zustand";
-import { createTodoStore } from "./createStore";
+import { createTodoStore, type TodoStoreDependencies } from "./createStore";
 import { useDirectoryWatcher } from "./hooks/useDirectoryWatcher";
+import { createTodoHostHelpers, type TinyHost, type TodoHostHelpers } from "../opfs";
 import type { TodoStore } from "./types";
 
 export const TodoContext = createContext<UseBoundStore<StoreApi<TodoStore>> | null>(null);
 
 export let useTodoStore: UseBoundStore<StoreApi<TodoStore>>;
 
-export function TodoProvider({ children }: PropsWithChildren) {
+interface TodoProviderProps extends PropsWithChildren {
+  host: TinyHost;
+}
+
+export function TodoProvider({ children, host }: TodoProviderProps) {
   const storeRef = useRef<UseBoundStore<StoreApi<TodoStore>> | null>(null);
+  const helpersRef = useRef<TodoHostHelpers | null>(null);
 
   if (!storeRef.current) {
-    useTodoStore = createTodoStore();
+    helpersRef.current = createTodoHostHelpers(host);
+    const dependencies: TodoStoreDependencies = {
+      fs: {
+        ensureDir: helpersRef.current.ensureDir,
+        listFiles: helpersRef.current.listFiles,
+        readFile: helpersRef.current.readFile,
+        writeFile: helpersRef.current.writeFile,
+        deleteFile: helpersRef.current.deleteFile,
+      },
+    };
+    useTodoStore = createTodoStore(dependencies);
     storeRef.current = useTodoStore;
+  } else if (!helpersRef.current) {
+    helpersRef.current = createTodoHostHelpers(host);
   }
 
   const store = storeRef.current!;
+  const helpers = helpersRef.current!;
 
-  useDirectoryWatcher(store);
+  useDirectoryWatcher(store, helpers);
 
   return <TodoContext.Provider value={store}>{children}</TodoContext.Provider>;
 }

--- a/clients/playground-new/src/example-plugins/todo/src/state/createStore.test.ts
+++ b/clients/playground-new/src/example-plugins/todo/src/state/createStore.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTodoStore, TODO_LISTS_DIR, type TodoStoreDependencies } from "./createStore";
+import type { TodoFileEntry } from "../opfs";
+
+const createDependencies = () => {
+  const ensureDir = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const listFiles = vi.fn<(path: string) => Promise<TodoFileEntry[]>>().mockResolvedValue([]);
+  const readFile = vi.fn<(path: string) => Promise<string>>().mockResolvedValue("- [ ] Task\n");
+  const writeFile = vi.fn<(path: string, contents: string) => Promise<void>>().mockResolvedValue(undefined);
+  const deleteFile = vi.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined);
+
+  const deps: TodoStoreDependencies = {
+    fs: { ensureDir, listFiles, readFile, writeFile, deleteFile },
+  };
+
+  return { deps, ensureDir, listFiles, readFile, writeFile, deleteFile };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createTodoStore", () => {
+  it("initializes and selects the first todo list", async () => {
+    const { deps, ensureDir, listFiles } = createDependencies();
+    listFiles.mockResolvedValueOnce([
+      { name: "work.md", path: "plugin_data/todo/work.md", kind: "file" as const },
+      { name: "alpha.md", path: "plugin_data/todo/alpha.md", kind: "file" as const },
+    ]);
+
+    const store = createTodoStore(deps);
+    await store.getState().initialize();
+
+    expect(ensureDir).toHaveBeenCalledWith(TODO_LISTS_DIR);
+    expect(listFiles).toHaveBeenCalledWith(TODO_LISTS_DIR);
+    expect(store.getState().lists).toEqual(["alpha.md", "work.md"]);
+    expect(store.getState().selectedList).toBe("alpha.md");
+  });
+
+  it("writes updated content when toggling a todo item", async () => {
+    const { deps, listFiles, readFile, writeFile } = createDependencies();
+    listFiles.mockResolvedValue([{ name: "demo.md", path: "plugin_data/todo/demo.md", kind: "file" as const }]);
+    readFile.mockResolvedValue("- [ ] Task\n");
+
+    const store = createTodoStore(deps);
+    await store.getState().refreshLists();
+
+    expect(store.getState().selectedList).toBe("demo.md");
+
+    await store.getState().setChecked(0, true);
+
+    expect(writeFile).toHaveBeenLastCalledWith(`${TODO_LISTS_DIR}/demo.md`, "- [x] Task\n");
+  });
+});

--- a/clients/playground-new/src/example-plugins/todo/src/window.tsx
+++ b/clients/playground-new/src/example-plugins/todo/src/window.tsx
@@ -1,26 +1,55 @@
-import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { ChakraProvider, Flex, Text, defaultSystem } from "@chakra-ui/react";
 import { createRoot } from "react-dom/client";
 import { TodoList } from "./component";
 import { TodoProvider } from "./state/TodoProvider";
+import type { TinyHost } from "./opfs";
 
-function TodoWindow() {
+interface TodoWindowProps {
+  host: TinyHost;
+}
+
+function isTinyHost(value: unknown): value is TinyHost {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return "fs" in record;
+}
+
+function resolveHost(provided: TinyHost | null | undefined): TinyHost | null {
+  if (provided) return provided;
+  const fallback = (window as typeof window & { __tinyUiHost__?: unknown }).__tinyUiHost__;
+  if (isTinyHost(fallback)) return fallback;
+  return null;
+}
+
+function TodoWindow({ host }: TodoWindowProps) {
   return (
-    <TodoProvider>
+    <TodoProvider host={host}>
       <TodoList />
     </TodoProvider>
   );
 }
 
-export function mount(container: Element | null) {
+function MissingHost() {
+  return (
+    <Flex align="center" justify="center" height="100%" padding="6">
+      <Text fontSize="sm" textAlign="center" color="foreground.subtle">
+        Tiny UI host is not available for the Todo plugin.
+      </Text>
+    </Flex>
+  );
+}
+
+export function mount(container: Element | null, host?: TinyHost | null) {
   if (!container) throw new Error("todo plugin mount target is not available");
 
   const target = container as HTMLElement;
   target.innerHTML = "";
   const root = createRoot(target);
+  const resolvedHost = resolveHost(host);
 
   root.render(
     <ChakraProvider value={defaultSystem}>
-      <TodoWindow />
+      {resolvedHost ? <TodoWindow host={resolvedHost} /> : <MissingHost />}
     </ChakraProvider>,
   );
 

--- a/clients/playground-new/vitest.config.ts
+++ b/clients/playground-new/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.{test,spec}.{ts,tsx}", "src/**/__tests__/*.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## Summary
- update the todo and file explorer example plugins to resolve the Tiny UI host at mount time and plumb it through providers/components
- replace OPFS helpers with host.fs/workspace adapters, including snapshot-driven watchers and workspace tree builders
- add vitest coverage for the todo store and configure the playground workspace for isolated tests

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: upstream @pstdio/opfs-utils suite relies on Array.fromAsync in WebAccess which is unavailable in this runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68ef80a8baa88321a9ea29b2018049a2