### PR TITLE
Enable parallel tool execution in createAgent

### DIFF
--- a/packages/@pstdio/tiny-ai-tasks/src/agents/createAgent.test.ts
+++ b/packages/@pstdio/tiny-ai-tasks/src/agents/createAgent.test.ts
@@ -48,4 +48,64 @@ describe("createAgent", () => {
     expect(final[0]).toMatchObject({ role: "user" });
     expect(final.some((m) => m.role === "tool" && (m as any).tool_call_id === "1")).toBe(true);
   });
+
+  it("runs multiple tool calls in parallel", async () => {
+    const llmImpl = vi.fn(async function* () {
+      const msg: AssistantMessage = {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          { id: "1", type: "function", function: { name: "slow", arguments: "{}" } },
+          { id: "2", type: "function", function: { name: "fast", arguments: "{}" } },
+        ],
+      };
+      yield msg;
+      return msg;
+    });
+
+    const llm = task("llm", llmImpl);
+
+    const completions: Record<string, number> = {};
+
+    const slow = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      completions.slow = Date.now();
+      return {
+        messages: [{ role: "tool", tool_call_id: "1", content: JSON.stringify({ success: true }) }],
+      };
+    });
+
+    const fast = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      completions.fast = Date.now();
+      return {
+        messages: [{ role: "tool", tool_call_id: "2", content: JSON.stringify({ success: true }) }],
+      };
+    });
+
+    const agent = createAgent({
+      llm,
+      tools: [
+        Tool(slow as any, { name: "slow", parameters: { type: "object" } }),
+        Tool(fast as any, { name: "fast", parameters: { type: "object" } }),
+      ],
+      maxTurns: 1,
+    });
+
+    const initial: MessageHistory = [{ role: "user", content: "hi" }];
+
+    const start = Date.now();
+    for await (const _ of agent(initial)) {
+      // exhaust iterator
+    }
+    const duration = Date.now() - start;
+
+    expect(slow).toHaveBeenCalledTimes(1);
+    expect(fast).toHaveBeenCalledTimes(1);
+
+    expect(completions.fast).toBeLessThan(completions.slow);
+
+    // Sequential execution would take >= 60ms; ensure we finish faster than that.
+    expect(duration).toBeLessThan(60);
+  });
 });


### PR DESCRIPTION
## Summary
- execute tool calls concurrently in `createAgent` while preserving ordered history updates
- add a regression test that verifies multiple tool calls complete in parallel

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: @pstdio/opfs-utils tests require Array.fromAsync in the environment)*
- npm run test --workspace @pstdio/tiny-ai-tasks -- --run src/agents/createAgent.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68f15a618b908321a83e8887112f5bea