### PR TITLE
Fix desktop window buttons on mobile

### DIFF
--- a/clients/playground-new/src/components/ui/window.tsx
+++ b/clients/playground-new/src/components/ui/window.tsx
@@ -72,11 +72,16 @@ const WindowChrome = (props: WindowChromeProps) => {
             {window.title}
           </Text>
         </HStack>
-        <HStack gap="2xs">
-          <IconButton aria-label={window.isMaximized ? "Restore" : "Maximize"} size="2xs" onClick={onMaximize}>
+        <HStack gap="2xs" className="desktop-window__drag-cancel">
+          <IconButton
+            aria-label={window.isMaximized ? "Restore" : "Maximize"}
+            size="2xs"
+            onClick={onMaximize}
+            className="desktop-window__drag-cancel"
+          >
             {window.isMaximized ? <Minimize2 size={14} /> : <Square size={14} />}
           </IconButton>
-          <IconButton aria-label="Close" size="2xs" onClick={onClose}>
+          <IconButton aria-label="Close" size="2xs" onClick={onClose} className="desktop-window__drag-cancel">
             <X size={14} />
           </IconButton>
         </HStack>
@@ -318,6 +323,7 @@ export const Window = (props: WindowProps) => {
       position={position}
       bounds="parent"
       dragHandleClassName="desktop-window__drag-handle"
+      cancel=".desktop-window__drag-cancel"
       onDragStart={handleDragStart}
       onDrag={handleDrag}
       onDragStop={handleDragStop}


### PR DESCRIPTION
## Summary
- add a drag-cancel class to the desktop window control buttons
- configure react-rnd to ignore the window control buttons when starting a drag

## Testing
- npm run format
- npm run lint *(fails: @pstdio/tiny-ui-bundler lint — unused `error` variable)*
- CI=1 npm run build --workspace playground-new
- npm run test *(fails: @pstdio/opfs-utils vitest — Array.fromAsync is not a function in zenfs)*

------
https://chatgpt.com/codex/tasks/task_e_68f20d01e3808321b8d90a2646569672