### PR TITLE
Add Vitest coverage for tiny-ui-bundler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25394,7 +25394,10 @@
       "dependencies": {
         "esbuild-wasm": "^0.25.10"
       },
-      "devDependencies": {},
+      "devDependencies": {
+        "@types/node": "^22.18.0",
+        "vitest": "^3.2.4"
+      },
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"

--- a/packages/@pstdio/tiny-ui-bundler/package.json
+++ b/packages/@pstdio/tiny-ui-bundler/package.json
@@ -39,7 +39,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "vitest": "^3.2.4"
+  },
   "dependencies": {
     "esbuild-wasm": "^0.25.10"
   },

--- a/packages/@pstdio/tiny-ui-bundler/tests/base-path.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/base-path.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getBasePath, resetBasePath, resolveBasePath, setBasePath } from "../src/core/base-path";
+
+describe("base-path", () => {
+  beforeEach(() => {
+    resetBasePath();
+  });
+
+  it("normalizes the registered base path", () => {
+    setBasePath("play");
+    expect(getBasePath()).toBe("/play/");
+
+    setBasePath("/root");
+    expect(getBasePath()).toBe("/root/");
+  });
+
+  it("resolves paths relative to the base", () => {
+    setBasePath("play");
+    expect(resolveBasePath("virtual/bundle.js")).toBe("/play/virtual/bundle.js");
+    expect(resolveBasePath("/virtual/bundle.js")).toBe("/play/virtual/bundle.js");
+
+    setBasePath("/");
+    expect(resolveBasePath("/virtual/bundle.js")).toBe("/virtual/bundle.js");
+    expect(resolveBasePath("")).toBe("/");
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/cache-manifest.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/cache-manifest.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { publishBundleToSW } from "../src/cache/cache";
+import { clearCachedCompileResult, getCachedBundle, setCachedCompileResult } from "../src/cache/cache-manifest";
+import { computeLockfileHash } from "../src/core/hash";
+import { setLockfile } from "../src/core/idb";
+import { CACHE_NAME, getManifestUrl } from "../src/constants";
+
+const SOURCE_ID = "source";
+
+const reset = async () => {
+  await caches.delete(CACHE_NAME);
+  setLockfile(null);
+};
+
+describe("cache-manifest", () => {
+  beforeEach(async () => {
+    await reset();
+  });
+
+  it("returns null when assets are missing", async () => {
+    const lockfile = { react: "https://esm.sh/react" };
+    setLockfile(lockfile);
+    const lockfileHash = await computeLockfileHash(lockfile);
+
+    const hash = "hash";
+    await publishBundleToSW({
+      hash,
+      entry: {
+        source: "console.log('hi')",
+        init: { headers: { "Content-Type": "application/javascript" } },
+      },
+      assets: [{ path: "assets/style.css", source: "body{}", init: { headers: { "Content-Type": "text/css" } } }],
+    });
+
+    await setCachedCompileResult(SOURCE_ID, {
+      id: SOURCE_ID,
+      hash,
+      url: `/virtual/${hash}.js`,
+      fromCache: false,
+      bytes: 42,
+      assets: ["assets/style.css"],
+      lockfileHash,
+    });
+
+    const hit = await getCachedBundle(SOURCE_ID);
+    expect(hit).not.toBeNull();
+
+    const cache = await caches.open(CACHE_NAME);
+    await cache.delete(`/virtual/${hash}/assets/style.css`);
+
+    const miss = await getCachedBundle(SOURCE_ID);
+    expect(miss).toBeNull();
+
+    const manifestResponse = await cache.match(getManifestUrl());
+    const manifest = manifestResponse ? await manifestResponse.json() : {};
+    expect(manifest[SOURCE_ID]).toBeUndefined();
+
+    await clearCachedCompileResult(SOURCE_ID);
+  });
+
+  it("invalidates cache when lockfile hash differs", async () => {
+    const hash = "hash";
+    setLockfile({ dep: "1.0.0" });
+    const lockfileHash = await computeLockfileHash({ dep: "1.0.0" });
+
+    await publishBundleToSW({
+      hash,
+      entry: {
+        source: "console.log('hi')",
+        init: { headers: { "Content-Type": "application/javascript" } },
+      },
+      assets: [],
+    });
+
+    await setCachedCompileResult(SOURCE_ID, {
+      id: SOURCE_ID,
+      hash,
+      url: `/virtual/${hash}.js`,
+      fromCache: false,
+      bytes: 12,
+      assets: [],
+      lockfileHash,
+    });
+
+    setLockfile({ dep: "2.0.0" });
+    const result = await getCachedBundle(SOURCE_ID);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/cache.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/cache.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getBundleCount, hasBundle, publishBundleToSW } from "../src/cache/cache";
+import { CACHE_NAME, buildVirtualUrl } from "../src/constants";
+
+const clearCache = async () => {
+  await caches.delete(CACHE_NAME);
+};
+
+describe("cache", () => {
+  beforeEach(async () => {
+    await clearCache();
+  });
+
+  it("publishes bundles and tracks entries", async () => {
+    await publishBundleToSW({
+      hash: "hash",
+      entry: {
+        source: "console.log('hi')",
+        init: { headers: { "Content-Type": "application/javascript" } },
+      },
+      assets: [{ path: "assets/style.css", source: "body{}", init: { headers: { "Content-Type": "text/css" } } }],
+    });
+
+    expect(await hasBundle("hash")).toBe(true);
+
+    const cache = await caches.open(CACHE_NAME);
+    const entry = await cache.match(buildVirtualUrl("hash"));
+    expect(entry).toBeDefined();
+
+    expect(await getBundleCount()).toBeGreaterThan(0);
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/compile.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/compile.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { compile } from "../src/esbuild/compile";
+import { registerSources, removeSource } from "../src/core/sources";
+import { registerVirtualSnapshot, unregisterVirtualSnapshot } from "../src/core/snapshot";
+import { setLockfile } from "../src/core/idb";
+import { getCachedBundle } from "../src/cache/cache-manifest";
+import { CACHE_NAME } from "../src/constants";
+
+vi.mock("esbuild-wasm", () => {
+  const encoder = new TextEncoder();
+  return {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    build: vi.fn().mockResolvedValue({
+      outputFiles: [
+        {
+          path: "out/bundle.js",
+          text: 'console.log("entry")',
+          contents: encoder.encode('console.log("entry")'),
+        },
+        {
+          path: "out/assets/style-1.css",
+          text: "body{}",
+          contents: encoder.encode("body{}"),
+        },
+        {
+          path: "out/chunks/chunk.js.map",
+          text: "{}",
+          contents: encoder.encode("{}"),
+        },
+      ],
+      metafile: {
+        outputs: {
+          "out/bundle.js": { entryPoint: "/index.ts" },
+          "out/assets/style-1.css": {},
+          "out/chunks/chunk.js.map": {},
+        },
+      },
+    }),
+  };
+});
+
+const SOURCE_ID = "compile";
+const ROOT = "/project";
+
+const resetEnvironment = async () => {
+  await caches.delete(CACHE_NAME);
+  setLockfile(null);
+  unregisterVirtualSnapshot(ROOT);
+  removeSource(SOURCE_ID);
+};
+
+beforeEach(async () => {
+  await resetEnvironment();
+});
+
+afterEach(async () => {
+  await resetEnvironment();
+});
+
+describe("compile", () => {
+  it("publishes outputs and reuses cached bundles", async () => {
+    registerSources([{ id: SOURCE_ID, root: ROOT, entry: `${ROOT}/index.ts` }]);
+    registerVirtualSnapshot(ROOT, {
+      entry: `${ROOT}/index.ts`,
+      files: {
+        [`${ROOT}/index.ts`]: "import './styles.css'; console.log('hi');",
+        [`${ROOT}/styles.css`]: "body{}",
+      },
+    });
+
+    const first = await compile(SOURCE_ID, { wasmURL: "/esbuild.wasm" });
+    expect(first.fromCache).toBe(false);
+    expect(first.url).toMatch(/^\/virtual\/.+\.js$/);
+    expect(first.assets).toContain("assets/style-1.css");
+
+    const second = await compile(SOURCE_ID, { wasmURL: "/esbuild.wasm" });
+    expect(second.fromCache).toBe(true);
+    expect(second.hash).toBe(first.hash);
+
+    const cached = await getCachedBundle(SOURCE_ID);
+    expect(cached).not.toBeNull();
+    expect(cached?.hash).toBe(first.hash);
+  });
+
+  it("forces a rebuild when skipCache is true", async () => {
+    registerSources([{ id: SOURCE_ID, root: ROOT, entry: `${ROOT}/index.ts` }]);
+    registerVirtualSnapshot(ROOT, {
+      entry: `${ROOT}/index.ts`,
+      files: {
+        [`${ROOT}/index.ts`]: "console.log('hi');",
+      },
+    });
+
+    const first = await compile(SOURCE_ID, { wasmURL: "/esbuild.wasm" });
+    const second = await compile(SOURCE_ID, { wasmURL: "/esbuild.wasm", skipCache: true });
+
+    expect(second.fromCache).toBe(false);
+    expect(second.hash).toBe(first.hash);
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/hash.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/hash.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { computeHash, computeLockfileHash, hashText } from "../src/core/hash";
+
+describe("hash", () => {
+  it("produces identical lockfile hashes for order-insensitive inputs", async () => {
+    const hashA = await computeLockfileHash({ react: "1.0.0", z: "2.0.0" });
+    const hashB = await computeLockfileHash({ z: "2.0.0", react: "1.0.0" });
+    expect(hashA).toBe(hashB);
+  });
+
+  it("changes the bundle hash when digests change", async () => {
+    const base = {
+      id: "id",
+      root: "/root",
+      entryRelativePath: "/index.tsx",
+      digests: { "/file": "digest-a" },
+      tsconfig: null,
+      lockfile: null,
+    };
+
+    const hashA = await computeHash(base);
+    const hashB = await computeHash({ ...base, digests: { "/file": "digest-b" } });
+    expect(hashA).not.toBe(hashB);
+  });
+
+  it("hashText is deterministic", async () => {
+    const first = await hashText("hello world");
+    const second = await hashText("hello world");
+    expect(first).toBe(second);
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/import-map.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/import-map.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { buildImportMap } from "../src/core/import-map";
+
+describe("import-map", () => {
+  it("mirrors the lockfile entries", () => {
+    const lockfile = {
+      react: "https://cdn/react.js",
+      "react-dom": "https://cdn/react-dom.js",
+    };
+
+    expect(buildImportMap(lockfile)).toEqual({ imports: lockfile });
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/setup.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/setup.ts
@@ -1,0 +1,87 @@
+import { webcrypto } from "node:crypto";
+import { TextDecoder, TextEncoder } from "node:util";
+
+if (typeof globalThis.crypto === "undefined") {
+  Object.defineProperty(globalThis, "crypto", { value: webcrypto, configurable: true });
+}
+
+if (typeof globalThis.TextEncoder === "undefined") {
+  Object.defineProperty(globalThis, "TextEncoder", { value: TextEncoder, configurable: true });
+}
+
+if (typeof globalThis.TextDecoder === "undefined") {
+  Object.defineProperty(globalThis, "TextDecoder", { value: TextDecoder, configurable: true });
+}
+
+class MemoryCache implements Cache {
+  private readonly store = new Map<string, Response>();
+
+  async match(request: RequestInfo | URL): Promise<Response | undefined> {
+    const key = this.keyFrom(request);
+    const stored = this.store.get(key);
+    return stored?.clone();
+  }
+
+  async put(request: RequestInfo | URL, response: Response): Promise<void> {
+    const key = this.keyFrom(request);
+    this.store.set(key, response.clone());
+  }
+
+  async delete(request: RequestInfo | URL): Promise<boolean> {
+    const key = this.keyFrom(request);
+    return this.store.delete(key);
+  }
+
+  async keys(): Promise<Request[]> {
+    return Array.from(this.store.keys()).map((url) => new Request(this.toAbsolute(url)));
+  }
+
+  private keyFrom(input: RequestInfo | URL): string {
+    if (typeof input === "string") return this.normalize(input);
+    if (input instanceof URL) return this.normalize(input.pathname);
+    const url = this.toAbsolute(input.url ?? String(input));
+    return this.normalize(new URL(url).pathname);
+  }
+
+  private normalize(path: string): string {
+    if (!path.startsWith("http")) return path.startsWith("/") ? path : `/${path}`;
+    return new URL(path).pathname;
+  }
+
+  private toAbsolute(path: string): string {
+    if (path.startsWith("http")) return path;
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    return `https://kaset.virtual${normalized}`;
+  }
+}
+
+class MemoryCaches implements CacheStorage {
+  private readonly caches = new Map<string, MemoryCache>();
+
+  async open(name: string): Promise<Cache> {
+    let cache = this.caches.get(name);
+    if (!cache) {
+      cache = new MemoryCache();
+      this.caches.set(name, cache);
+    }
+    return cache;
+  }
+
+  async has(name: string): Promise<boolean> {
+    return this.caches.has(name);
+  }
+
+  async delete(name: string): Promise<boolean> {
+    return this.caches.delete(name);
+  }
+
+  async keys(): Promise<string[]> {
+    return Array.from(this.caches.keys());
+  }
+
+  match(): Promise<Response | undefined> {
+    return Promise.resolve(undefined);
+  }
+}
+
+(globalThis as unknown as { caches: CacheStorage }).caches = new MemoryCaches();

--- a/packages/@pstdio/tiny-ui-bundler/tests/snapshot.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/snapshot.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { registerVirtualSnapshot, readSnapshot, unregisterVirtualSnapshot } from "../src/core/snapshot";
+import { registerSources, removeSource } from "../src/core/sources";
+
+describe("snapshot", () => {
+  const root = "/workspace/project";
+  const id = "snapshot";
+
+  afterEach(() => {
+    unregisterVirtualSnapshot(root);
+    removeSource(id);
+  });
+
+  it("builds digests and ensures entry presence", async () => {
+    const config = { id, root, entry: `${root}/src/index.tsx` } as const;
+    registerSources([config]);
+    registerVirtualSnapshot(root, {
+      entry: `${root}/src/index.tsx`,
+      files: {
+        [`${root}/src/index.tsx`]: "console.log('hello')",
+        [`${root}/src/components/Button.tsx`]: "export const Button = () => null;",
+      },
+    });
+
+    const snapshot = await readSnapshot(config);
+    expect(snapshot.entryRelative).toBe("/src/index.tsx");
+    expect(Object.keys(snapshot.files)).toContain("/src/components/Button.tsx");
+    expect(snapshot.digests["/src/index.tsx"]).toBeDefined();
+  });
+
+  it("throws when the entry file is missing", async () => {
+    const config = { id, root, entry: `${root}/src/index.tsx` } as const;
+    registerSources([config]);
+    registerVirtualSnapshot(root, {
+      files: {
+        [`${root}/src/components/Button.tsx`]: "export const Button = () => null;",
+      },
+    });
+
+    await expect(readSnapshot(config)).rejects.toThrow(
+      /Virtual snapshot for snapshot is missing entry file \/src\/index.tsx/,
+    );
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/sources.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/sources.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getSource, registerSources, removeSource, updateSource } from "../src/core/sources";
+
+describe("sources", () => {
+  afterEach(() => {
+    removeSource("alpha");
+  });
+
+  it("registers and clones source configs", () => {
+    registerSources([{ id: "alpha", root: "/root" }]);
+    const first = getSource("alpha");
+    expect(first).toEqual({ id: "alpha", root: "/root" });
+
+    if (!first) throw new Error("expected source");
+    first.root = "/mutated";
+    const second = getSource("alpha");
+    expect(second).toEqual({ id: "alpha", root: "/root" });
+  });
+
+  it("updates registered sources", () => {
+    registerSources([{ id: "alpha", root: "/root" }]);
+    updateSource({ id: "alpha", root: "/updated" });
+    expect(getSource("alpha")).toEqual({ id: "alpha", root: "/updated" });
+  });
+
+  it("removes source configs", () => {
+    registerSources([{ id: "alpha", root: "/root" }]);
+    removeSource("alpha");
+    expect(getSource("alpha")).toBeUndefined();
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/tests/utils.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/tests/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { ensureLeadingSlash, isHttpUrl, joinPath, loaderFromPath } from "../src/utils";
+
+describe("utils", () => {
+  it("ensureLeadingSlash", () => {
+    expect(ensureLeadingSlash("a/b")).toBe("/a/b");
+    expect(ensureLeadingSlash("/a")).toBe("/a");
+  });
+
+  it("loaderFromPath strips query/hash and maps extensions", () => {
+    expect(loaderFromPath("/x.ts")).toBe("ts");
+    expect(loaderFromPath("/x.tsx")).toBe("tsx");
+    expect(loaderFromPath("/x.js")).toBe("js");
+    expect(loaderFromPath("/x.jsx")).toBe("jsx");
+    expect(loaderFromPath("/x.json")).toBe("json");
+    expect(loaderFromPath("/x.css")).toBe("css");
+    expect(loaderFromPath("/x.mjs?foo=1#bar")).toBe("js");
+    expect(loaderFromPath("/x.unknown")).toBe("js");
+  });
+
+  it("isHttpUrl", () => {
+    expect(isHttpUrl("https://a")).toBe(true);
+    expect(isHttpUrl("http://a")).toBe(true);
+    expect(isHttpUrl("/a")).toBe(false);
+  });
+
+  it("joinPath resolves relative segments", () => {
+    expect(joinPath("/a/b/c.ts", "./d")).toBe("/a/b/d");
+    expect(joinPath("/a/b/c.ts", "../d")).toBe("/a/d");
+    expect(joinPath("/a/b/c.ts", "/z")).toBe("/z");
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/vitest.config.ts
+++ b/packages/@pstdio/tiny-ui-bundler/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: ["./tests/setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- configure Vitest for `@pstdio/tiny-ui-bundler` with a Node test environment and shared setup
- add unit tests covering utilities, registries, caching, and compile flows for the bundler package
- declare Vitest dev dependencies for the bundler workspace

## Testing
- npm run format
- npm run lint -- --scope @pstdio/tiny-ui-bundler
- npm run build -- --scope @pstdio/tiny-ui-bundler
- npm run test -- --scope @pstdio/tiny-ui-bundler

------
https://chatgpt.com/codex/tasks/task_e_68f2491534148321a8ce81d60918836e