### PR TITLE
Add default approval-gated tool list to playground settings

### DIFF
--- a/clients/playground-new/src/components/ui/settings-modal.tsx
+++ b/clients/playground-new/src/components/ui/settings-modal.tsx
@@ -1,4 +1,4 @@
-import { ROOT } from "@/constant";
+import { APPROVAL_GATED_TOOL_IDS, ROOT } from "@/constant";
 import { getWorkspaceSettings } from "@/state/actions/getWorkspaceSettings";
 import { saveWorkspaceSettings } from "@/state/actions/saveWorkspaceSettings";
 import type { McpServerConfig, ThemePreference } from "@/state/types";
@@ -94,7 +94,8 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
     setApiKey(settings.apiKey ?? "");
     setBaseUrl(settings.baseUrl ?? "");
     setModel(settings.modelId || "gpt-5");
-    setApprovalTools(settings.approvalGatedTools || []);
+    const gatedTools = settings.approvalGatedTools ? [...settings.approvalGatedTools] : [...APPROVAL_GATED_TOOL_IDS];
+    setApprovalTools(gatedTools);
 
     const nextTheme = settings.theme ?? "light";
     setTheme(nextTheme);
@@ -504,7 +505,7 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
                     <Flex gap="xs" direction="column" width="100%">
                       <Text>Approval-gated tools</Text>
                       <VStack align="stretch">
-                        {[].map((tool) => (
+                        {APPROVAL_GATED_TOOL_IDS.map((tool) => (
                           <Checkbox.Root
                             key={tool}
                             checked={approvalTools.includes(tool)}

--- a/clients/playground-new/src/constant.ts
+++ b/clients/playground-new/src/constant.ts
@@ -2,6 +2,16 @@ export const ROOT = "playground";
 export const PLUGIN_ROOT = `${ROOT}/plugins`;
 export const PLUGIN_DATA_ROOT = `${ROOT}/plugin_data`;
 
+export const APPROVAL_GATED_TOOL_IDS = [
+  "opfs_write_file",
+  "opfs_delete_file",
+  "opfs_patch",
+  "opfs_upload_files",
+  "opfs_move_file",
+] as const;
+
+export const DEFAULT_APPROVAL_GATED_TOOLS = [...APPROVAL_GATED_TOOL_IDS];
+
 export const examplePrompts = [
   "What can you do?",
   "Add a button to the hello-kaset plugin that makes confetti",

--- a/clients/playground-new/src/state/defaultState.ts
+++ b/clients/playground-new/src/state/defaultState.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_APPROVAL_GATED_TOOLS } from "../constant";
 import type { ThemePreference, WorkspaceState } from "./types";
 
 export const DEFAULT_STATE: WorkspaceState = {
@@ -18,7 +19,7 @@ export const DEFAULT_STATE: WorkspaceState = {
     modelId: "gpt-5",
     baseUrl: "",
     apiKey: "",
-    approvalGatedTools: [],
+    approvalGatedTools: [...DEFAULT_APPROVAL_GATED_TOOLS],
     mcpServers: [],
     activeMcpServerIds: [],
     theme: "light" satisfies ThemePreference,


### PR DESCRIPTION
## Summary
- define the approval-gated tool ids for the playground client so settings can surface them
- initialize workspace settings with the default approval-gated tool list
- render the approval gating options in the settings modal using the shared list

## Testing
- npm run format
- CI=1 npm run lint
- CI=1 npm run build
- CI=1 npm run test *(fails: @pstdio/opfs-utils:test → Array.fromAsync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68f40458b6248321848f3e11e37d20a7