### PR TITLE
Handle OPFS patch diff rendering via shared helper

### DIFF
--- a/clients/playground-new/src/components/conversation/utils/diff.ts
+++ b/clients/playground-new/src/components/conversation/utils/diff.ts
@@ -14,10 +14,13 @@ function normalizeHeaderPath(input?: string | null): string | null {
   const token = input.split("\t")[0].trim();
   if (token === "/dev/null") return null;
 
-  if (token.startsWith("a/") || token.startsWith("b/")) {
-    return token.slice(2);
+  let normalized = token;
+  if (normalized.startsWith("a/") || normalized.startsWith("b/")) {
+    normalized = normalized.slice(2);
   }
-  return token;
+
+  normalized = normalized.replace(/^\/+/, "").replace(/\\/g, "/");
+  return normalized;
 }
 
 export function parseUnifiedDiff(diffText?: string): FileChange[] {
@@ -121,6 +124,83 @@ export function buildDiffTitleSegments(inv: ToolInvocation): TitleSegment[] {
     additions: f.additions,
     deletions: f.deletions,
   }));
+}
+
+export type FileDiffPreview = { filePath: string; original: string; modified: string };
+
+export function buildFileDiffPreviews(diffText?: string): FileDiffPreview[] {
+  if (!diffText || typeof diffText !== "string") return [];
+
+  const lines = diffText.split(/\r?\n/);
+  const previews: FileDiffPreview[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i] || "";
+    if (!line.startsWith("--- ")) {
+      i += 1;
+      continue;
+    }
+
+    const oldHeader = normalizeHeaderPath(line.slice(4));
+    const next = lines[i + 1] || "";
+    if (!next.startsWith("+++ ")) {
+      i += 1;
+      continue;
+    }
+
+    const newHeader = normalizeHeaderPath(next.slice(4));
+    const filePath = newHeader ?? oldHeader ?? "";
+    i += 2;
+
+    const original: string[] = [];
+    const modified: string[] = [];
+
+    while (i < lines.length) {
+      const current = lines[i] || "";
+      if (current.startsWith("--- ") || current.startsWith("diff --git ")) break;
+
+      if (current.startsWith("@@")) {
+        i += 1;
+        while (i < lines.length) {
+          const body = lines[i] || "";
+          if (
+            body.startsWith("--- ") ||
+            body.startsWith("@@") ||
+            body.startsWith("diff --git ") ||
+            (!body.startsWith(" ") && !body.startsWith("+") && !body.startsWith("-") && body.trim() !== "")
+          ) {
+            break;
+          }
+
+          if (body.startsWith(" ")) {
+            const text = body.slice(1);
+            original.push(text);
+            modified.push(text);
+          } else if (body.startsWith("-")) {
+            original.push(body.slice(1));
+          } else if (body.startsWith("+")) {
+            modified.push(body.slice(1));
+          }
+
+          i += 1;
+        }
+
+        if (original.length > 0 || modified.length > 0) {
+          original.push("");
+          modified.push("");
+        }
+
+        continue;
+      }
+
+      i += 1;
+    }
+
+    previews.push({ filePath, original: original.join("\n"), modified: modified.join("\n") });
+  }
+
+  return previews;
 }
 
 export function summarizeConversationChanges(messages: UIMessage[]): {

--- a/clients/playground-new/src/components/conversation/utils/timeline.ts
+++ b/clients/playground-new/src/components/conversation/utils/timeline.ts
@@ -1,6 +1,6 @@
 import type { TimelineDoc, TitleSegment } from "@/components/ui/timeline";
 import type { ToolInvocation } from "@pstdio/kas/kas-ui";
-import { buildDiffTitleSegments } from "./diff";
+import { buildDiffTitleSegments, buildFileDiffPreviews } from "./diff";
 import { toolTypeToIconName } from "./toolIcon";
 import { renderOpfsTool } from "./opfsTools";
 
@@ -25,93 +25,6 @@ function guessLanguageFromPath(filePath?: string): string | undefined {
   if (name.endsWith(".html") || name.endsWith(".htm")) return "html";
   if (name.endsWith(".yaml") || name.endsWith(".yml")) return "yaml";
   return undefined;
-}
-
-type FileDiffPreview = { filePath: string; original: string; modified: string };
-
-function buildFileDiffPreviews(diffText?: string): FileDiffPreview[] {
-  if (!diffText || typeof diffText !== "string") return [];
-
-  const lines = diffText.split(/\r?\n/);
-  const previews: FileDiffPreview[] = [];
-
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i] || "";
-    if (line.startsWith("--- ")) {
-      const oldHeader = line.slice(4).split("\t")[0].trim();
-      const next = lines[i + 1] || "";
-      if (!next.startsWith("+++ ")) {
-        i += 1;
-        continue;
-      }
-      const newHeader = next.slice(4).split("\t")[0].trim();
-
-      // Normalize a/ b/ prefixes and /dev/null
-      const norm = (p: string) =>
-        p === "/dev/null"
-          ? null
-          : p
-              .replace(/^([ab]\/)*/, "")
-              .replace(/^\/+/, "")
-              .replace(/\\/g, "/");
-
-      const oldPath = norm(oldHeader);
-      const newPath = norm(newHeader);
-      const filePath = newPath ?? oldPath ?? "";
-      i += 2;
-
-      const orig: string[] = [];
-      const mod: string[] = [];
-
-      while (i < lines.length) {
-        const l = lines[i] || "";
-        if (l.startsWith("--- ") || l.startsWith("diff --git ")) break;
-        if (l.startsWith("@@")) {
-          // Start of a hunk: we simply accumulate hunk body lines below
-          i += 1;
-          while (i < lines.length) {
-            const body = lines[i] || "";
-            if (
-              body.startsWith("--- ") ||
-              body.startsWith("@@") ||
-              body.startsWith("diff --git ") ||
-              (!body.startsWith(" ") && !body.startsWith("+") && !body.startsWith("-") && body.trim() !== "")
-            ) {
-              break;
-            }
-
-            if (body.startsWith(" ")) {
-              const t = body.slice(1);
-              orig.push(t);
-              mod.push(t);
-            } else if (body.startsWith("-")) {
-              orig.push(body.slice(1));
-            } else if (body.startsWith("+")) {
-              mod.push(body.slice(1));
-            }
-
-            i += 1;
-          }
-          // Add blank line separator between hunks for readability
-          if (orig.length > 0 || mod.length > 0) {
-            orig.push("");
-            mod.push("");
-          }
-          continue;
-        }
-
-        // Skip non-hunk lines until next file or hunk
-        i += 1;
-      }
-
-      previews.push({ filePath, original: orig.join("\n"), modified: mod.join("\n") });
-      continue;
-    }
-    i += 1;
-  }
-
-  return previews;
 }
 
 export function invocationsToTimeline(invocations: ToolInvocation[], opts?: { labeledBlocks?: boolean }): TimelineDoc {


### PR DESCRIPTION
## Summary
- move the diff preview builder into the shared diff utilities so OPFS helpers can reuse it
- render `tool-opfs_patch` states inside `renderOpfsTool`, including diff previews and fallbacks
- simplify the timeline utility to rely on the shared helper when diff previews are needed

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: `Array.fromAsync is not a function` in @pstdio/opfs-utils vitest suite)*

------
https://chatgpt.com/codex/tasks/task_e_68f412d2a10c8321bb1cdb29dc1ce5da