### PR TITLE
Fix incremental prompt token estimation

### DIFF
--- a/clients/playground-new/src/components/conversation/hooks/useEstimatedTokens.ts
+++ b/clients/playground-new/src/components/conversation/hooks/useEstimatedTokens.ts
@@ -79,12 +79,14 @@ export function useEstimatedTokens(messages: UIMessage[], input: string): TokenU
 
       if (trimmed) {
         const history = toBaseMessages(messages);
-        const withCurrent: BaseMessage[] = [...history, { role: "user", content: trimmed } as BaseMessage];
-
         const counter = roughCounter();
+        const historyPromptTokens = counter.count(history);
+        const withCurrent: BaseMessage[] = [...history, { role: "user", content: trimmed } as BaseMessage];
         const estimatedPromptTokens = counter.count(withCurrent);
-        conversationPromptTokens = conversationPromptTokens + estimatedPromptTokens;
-        conversationTotalTokens = conversationTotalTokens + estimatedPromptTokens;
+        const incrementalPromptTokens = Math.max(estimatedPromptTokens - historyPromptTokens, 0);
+
+        conversationPromptTokens += incrementalPromptTokens;
+        conversationTotalTokens += incrementalPromptTokens;
       }
 
       return {


### PR DESCRIPTION
## Summary
- adjust the pending input estimation to compute incremental prompt tokens from the existing history
- update the conversation totals to add only the new prompt tokens rather than the full history

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: depends on Array.fromAsync in @pstdio/opfs-utils vitest suite)*

------
https://chatgpt.com/codex/tasks/task_e_68f4ba73a2c48321851820858d451636