### PR TITLE
Memoize plugin host API callbacks

### DIFF
--- a/packages/@pstdio/tiny-plugins/src/react/usePluginHost.ts
+++ b/packages/@pstdio/tiny-plugins/src/react/usePluginHost.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Tool } from "@pstdio/tiny-ai-tasks";
 import type { PluginCommand, PluginHostRuntime, PluginSettingsSchema } from "../runtime/pluginHostRuntime";
 
@@ -77,15 +77,29 @@ export function usePluginHost(runtime: PluginHostRuntime): UsePluginHostResult {
     };
   }, [runtime]);
 
+  const runCommand = useCallback(
+    (pluginId: string, commandId: string, params?: unknown) => runtime.runCommand(pluginId, commandId, params),
+    [runtime],
+  );
+
+  const getDisplayName = useCallback((pluginId: string) => runtime.getPluginDisplayName(pluginId), [runtime]);
+
+  const readSettings = useCallback(<T = unknown>(pluginId: string) => runtime.readSettings<T>(pluginId), [runtime]);
+
+  const writeSettings = useCallback(
+    <T = unknown>(pluginId: string, value: T) => runtime.writeSettings(pluginId, value),
+    [runtime],
+  );
+
   return {
     commands,
     tools,
     settings,
     loading,
     error,
-    runCommand: (pluginId, commandId, params) => runtime.runCommand(pluginId, commandId, params),
-    getDisplayName: (pluginId) => runtime.getPluginDisplayName(pluginId),
-    readSettings: (pluginId) => runtime.readSettings(pluginId),
-    writeSettings: (pluginId, value) => runtime.writeSettings(pluginId, value),
+    runCommand,
+    getDisplayName,
+    readSettings,
+    writeSettings,
   };
 }


### PR DESCRIPTION
## Summary
- memoize the plugin host runCommand, getDisplayName, readSettings, and writeSettings callbacks so consumers receive stable references

## Testing
- npm run format
- npm run lint --workspace @pstdio/tiny-plugins
- npm run build --workspace @pstdio/tiny-plugins
- npm run test *(fails: @pstdio/opfs-utils vitest suite requires Array.fromAsync support in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f55f0855d08321bc522759d5aeaca8