### PR TITLE
Route desktop preview API through shared event flow

### DIFF
--- a/clients/playground/src/services/desktop/desktop-api.ts
+++ b/clients/playground/src/services/desktop/desktop-api.ts
@@ -1,7 +1,7 @@
-import { openDesktopFilePreview } from "@/state/actions/desktop";
+import { requestOpenDesktopFile } from "./desktop-file-icons";
 
 export const desktopAPI = {
   "desktop.openFilePreview": (payload: { path: string }) => {
-    openDesktopFilePreview(payload.path);
+    requestOpenDesktopFile(payload.path);
   },
 };


### PR DESCRIPTION
## Summary
- dispatch the `desktop.openFilePreview` handler through `requestOpenDesktopFile` so desktop file previews reuse the shared registration flow

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: @pstdio/opfs-utils vitest suite requires Array.fromAsync support)*

------
https://chatgpt.com/codex/tasks/task_e_68f64f975c9c83219881f3d494d233f3