### PR TITLE
Clear Tiny UI caches when resetting the playground

### DIFF
--- a/clients/playground/src/services/playground/reset.ts
+++ b/clients/playground/src/services/playground/reset.ts
@@ -1,11 +1,37 @@
 import { ROOT } from "@/constant";
 import { deleteDirectoryContents, ls } from "@pstdio/opfs-utils";
+import { CACHE_NAME } from "@pstdio/tiny-ui";
 
 import { setupPlayground } from "./setup";
 
 export type ResetOptions = {
   rootDir?: string;
 };
+
+const TINY_UI_CACHE_PREFIX = "tiny-ui-";
+
+async function clearTinyUiCaches() {
+  if (!("caches" in globalThis)) return 0;
+
+  try {
+    const keys = await caches.keys();
+    let cleared = 0;
+
+    for (const key of keys) {
+      if (key === CACHE_NAME || key.startsWith(TINY_UI_CACHE_PREFIX)) {
+        const deleted = await caches.delete(key);
+        if (deleted) {
+          cleared += 1;
+        }
+      }
+    }
+
+    return cleared;
+  } catch (error) {
+    console.warn("[resetPlayground] Failed to clear Tiny UI caches", error);
+    return 0;
+  }
+}
 
 export async function resetPlayground(options: ResetOptions = {}) {
   const rootDir = options.rootDir?.trim() || ROOT;
@@ -32,6 +58,8 @@ export async function resetPlayground(options: ResetOptions = {}) {
     console.warn(`Failed to delete contents during reset at ${normalizedRoot}`, error);
   }
 
+  const cacheCleared = await clearTinyUiCaches();
+
   const setupResult = await setupPlayground({ rootDir: normalizedRoot, overwrite: true });
 
   return {
@@ -41,5 +69,6 @@ export async function resetPlayground(options: ResetOptions = {}) {
     rootFiles: setupResult.rootFiles,
     pluginFiles: setupResult.pluginFiles,
     pluginDataFiles: setupResult.pluginDataFiles,
+    cachesCleared: cacheCleared,
   };
 }


### PR DESCRIPTION
## Summary
- clear cached Tiny UI bundles when the playground is reset so new plugin builds load immediately
- expose the number of cache scopes removed alongside the existing reset metadata

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: Array.fromAsync is not a function in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f650a60690832191e9e3ef1f32aeb8