### PR TITLE
fix: default to bundled desktop wallpaper

### DIFF
--- a/clients/playground/src/components/ui/settings-modal.tsx
+++ b/clients/playground/src/components/ui/settings-modal.tsx
@@ -1,4 +1,4 @@
-import { APPROVAL_GATED_TOOL_IDS, ROOT } from "@/constant";
+import { APPROVAL_GATED_TOOL_IDS, DEFAULT_WALLPAPER, ROOT } from "@/constant";
 import { getWorkspaceSettings } from "@/state/actions/getWorkspaceSettings";
 import { saveWorkspaceSettings } from "@/state/actions/saveWorkspaceSettings";
 import type { McpServerConfig, ThemePreference } from "@/state/types";
@@ -46,7 +46,6 @@ const SETTINGS_SECTIONS: Array<{ id: SettingsSectionId; label: string }> = [
 ];
 
 const MobileSectionSelect = chakra("select");
-const DEFAULT_WALLPAPER = `${ROOT}/wallpaper/kaset.png`;
 
 const toBlobPart = (bytes: Uint8Array) => {
   if (bytes.buffer instanceof ArrayBuffer) {

--- a/clients/playground/src/constant.ts
+++ b/clients/playground/src/constant.ts
@@ -1,6 +1,7 @@
 export const ROOT = "playground";
 export const PLUGIN_ROOT = `${ROOT}/plugins`;
 export const PLUGIN_DATA_ROOT = `${ROOT}/plugin_data`;
+export const DEFAULT_WALLPAPER = `${ROOT}/wallpaper/kaset.png`;
 
 export const APPROVAL_GATED_TOOL_IDS = [
   "opfs_write_file",

--- a/clients/playground/src/state/actions/saveWorkspaceSettings.ts
+++ b/clients/playground/src/state/actions/saveWorkspaceSettings.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_WALLPAPER } from "../../constant";
 import { useWorkspaceStore } from "../WorkspaceProvider";
 import type { WorkspaceSettings } from "../types";
 
@@ -12,7 +13,7 @@ export const saveWorkspaceSettings = (settings: WorkspaceSettings, actionName = 
       state.settings.activeMcpServerIds =
         settings.activeMcpServerIds && settings.activeMcpServerIds.length > 0 ? [...settings.activeMcpServerIds] : [];
       state.settings.theme = settings.theme ?? "light";
-      state.settings.wallpaper = settings.wallpaper ?? "kaset.png";
+      state.settings.wallpaper = settings.wallpaper ?? DEFAULT_WALLPAPER;
       state.settings.reactScanEnabled = settings.reactScanEnabled ?? false;
     },
     false,

--- a/clients/playground/src/state/defaultState.ts
+++ b/clients/playground/src/state/defaultState.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_APPROVAL_GATED_TOOLS } from "../constant";
+import { DEFAULT_APPROVAL_GATED_TOOLS, DEFAULT_WALLPAPER } from "../constant";
 import type { ThemePreference, WorkspaceState } from "./types";
 
 export const DEFAULT_STATE: WorkspaceState = {
@@ -23,7 +23,7 @@ export const DEFAULT_STATE: WorkspaceState = {
     mcpServers: [],
     activeMcpServerIds: [],
     theme: "light" satisfies ThemePreference,
-    wallpaper: "kaset.png",
+    wallpaper: DEFAULT_WALLPAPER,
     reactScanEnabled: false,
   },
 };


### PR DESCRIPTION
## Summary
- add a shared `DEFAULT_WALLPAPER` constant that points to the bundled wallpaper
- initialize and persist workspace settings with the full wallpaper path so the desktop loads it by default
- reuse the shared constant in the settings modal to keep the fallback preview in sync

## Testing
- npm run format
- npm run lint
- npm run build
- npm run test *(fails: vitest for @pstdio/opfs-utils requires Array.fromAsync which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f65d2c49248321871523881af2d43a