### PR TITLE
Remove Tiny UI cache prefix usage during playground reset

### DIFF
--- a/clients/playground/src/services/playground/reset.ts
+++ b/clients/playground/src/services/playground/reset.ts
@@ -1,5 +1,6 @@
 import { ROOT } from "@/constant";
 import { deleteDirectoryContents, ls } from "@pstdio/opfs-utils";
+import { CACHE_NAME } from "@pstdio/tiny-ui";
 
 import { setupPlayground } from "./setup";
 
@@ -30,6 +31,14 @@ export async function resetPlayground(options: ResetOptions = {}) {
     await deleteDirectoryContents(normalizedRoot);
   } catch (error) {
     console.warn(`Failed to delete contents during reset at ${normalizedRoot}`, error);
+  }
+
+  try {
+    if ("caches" in globalThis) {
+      await caches.delete(CACHE_NAME);
+    }
+  } catch (error) {
+    console.warn("Failed to clear Tiny UI caches during reset", error);
   }
 
   const setupResult = await setupPlayground({ rootDir: normalizedRoot, overwrite: true });


### PR DESCRIPTION
## Summary
- clear Tiny UI caches during playground reset by deleting the shared cache name directly
- stop exporting the CACHE_NAME_PREFIX constant from the bundler and Tiny UI packages
- restore the Tiny UI service worker to use its local cache prefix definition

## Testing
- npm run format
- npm run lint
- NX_OUTPUT_STYLE=stream npm run build
- NX_OUTPUT_STYLE=stream npm run test *(fails: Array.fromAsync is not a function in the Vitest environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f650a60690832191e9e3ef1f32aeb8