### PR TITLE
chore: add opfs-sync npm support metadata

### DIFF
--- a/packages/@pstdio/opfs-sync/package.json
+++ b/packages/@pstdio/opfs-sync/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/pufflyai/kaset.git"
   },
+  "homepage": "https://github.com/pufflyai/kaset/tree/main/packages/@pstdio/opfs-sync#readme",
+  "bugs": {
+    "url": "https://github.com/pufflyai/kaset/issues"
+  },
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary

- Adds `homepage` metadata for `@pstdio/opfs-sync`
- Adds `bugs.url` metadata pointing to the upstream issue tracker

## Why

The package already declares its GitHub repository, but the npm metadata does not expose direct README/support links. Adding these fields improves package discoverability and gives users a clear place to report issues from npm clients and package pages.

## Testing

- Parsed `packages/@pstdio/opfs-sync/package.json` with Node to confirm valid JSON
- Confirmed the new `homepage` and `bugs.url` values
- Ran `git diff --check`
