### PR TITLE
fix(ci): build docs from package dir so vitepress resolves (fixes ENOENT)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,8 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build
-        run: bun run --filter documentation build
+        working-directory: clients/documentation
+        run: bun run build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Problem

The **Deploy docs to GitHub Pages** workflow has been failing on `main` since #223 with:

```
error: ENOENT
Process completed with exit code 1
```

The error fires in ~11ms, before VitePress runs — `bun` cannot exec the `vitepress` binary.

## Root cause

`vitepress` is not hoisted to the root `node_modules/.bin`; it only exists at `clients/documentation/node_modules/.bin/vitepress`. The migration in #223 changed the build step from `npm run build --workspace documentation` to `bun run --filter documentation build`. On **Linux**, bun's `--filter` invocation does not add the package-local `node_modules/.bin` to `PATH`, so the binary isn't found. (It happens to resolve on macOS, which is why it wasn't caught locally.)

## Fix

Run the build from the package directory, where the local `.bin` resolves on every platform:

```yaml
- name: Build
  working-directory: clients/documentation
  run: bun run build
```

## Validation

Reproduced and verified in a clean git worktree with `bun install --frozen-lockfile` (mirroring CI): the old `--filter` command's binary resolution is the issue, and the new `working-directory` form builds successfully (`build complete`).