### PR TITLE
Add @pstdio/kas-tracing: browser-first LangSmith tracing

### DIFF
--- a/.changeset/kas-tracing-langsmith.md
+++ b/.changeset/kas-tracing-langsmith.md
@@ -1,0 +1,5 @@
+---
+"@pstdio/kas-tracing": minor
+---
+
+Add `@pstdio/kas-tracing`: browser-first LangSmith tracing for `@pstdio` AI agents. Wrap a `Model` or `Tool` and stream a nested root → LLM → tool run tree to LangSmith using the `RunTree` API with explicit parent references (no `AsyncLocalStorage`), so nesting works client-side. Includes a configurable endpoint for US/EU regions and a zero-overhead passthrough when disabled.

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "@modelcontextprotocol/sdk": "^1.18.1",
         "@monaco-editor/react": "^4.7.0",
         "@pstdio/kas": "*",
+        "@pstdio/kas-tracing": "*",
         "@pstdio/opfs-hooks": "*",
         "@pstdio/opfs-utils": "*",
         "@pstdio/prompt-utils": "*",
@@ -115,6 +116,21 @@
       "devDependencies": {
         "@au-re/vite-plugin-externalize-deps": "^0.9.1",
         "@types/node": "^22.15.18",
+        "typescript": "^5.7.3",
+        "vite": "^7.1.0",
+        "vite-plugin-dts": "^4.5.4",
+        "vitest": "^3.2.4",
+      },
+    },
+    "packages/@pstdio/kas-tracing": {
+      "name": "@pstdio/kas-tracing",
+      "version": "0.0.0",
+      "dependencies": {
+        "@pstdio/tiny-ai-tasks": "^0.2.1",
+        "langsmith": "^0.7.11",
+      },
+      "devDependencies": {
+        "@au-re/vite-plugin-externalize-deps": "^0.9.1",
         "typescript": "^5.7.3",
         "vite": "^7.1.0",
         "vite-plugin-dts": "^4.5.4",
@@ -983,6 +999,8 @@
     "@preact/signals-core": ["@preact/signals-core@1.14.3", "", {}, "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw=="],
 
     "@pstdio/kas": ["@pstdio/kas@workspace:packages/@pstdio/kas"],
+
+    "@pstdio/kas-tracing": ["@pstdio/kas-tracing@workspace:packages/@pstdio/kas-tracing"],
 
     "@pstdio/opfs-hooks": ["@pstdio/opfs-hooks@workspace:packages/@pstdio/opfs-hooks"],
 
@@ -2469,6 +2487,8 @@
     "knip": ["knip@5.88.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-tpy5o7zu1MjawVkLPuahymVJekYY3kYjvzcoInhIchgePxTlo+api90tBv2KfhAIe5uXh+mez1tAfmbv8/TiZg=="],
 
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
+
+    "langsmith": ["langsmith@0.7.11", "", { "dependencies": { "p-queue": "6.6.2" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*", "ws": ">=7" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai", "ws"] }, "sha512-kK7tjvLo3KbyrXonZDJJMvX6jE5Ek9uwqtS2WX8AEGc5IwLoMrJlGR8wWk1UD8H/x0goiJDMsRht4qZd7Ijvcg=="],
 
     "lerna": ["lerna@8.2.4", "", { "dependencies": { "@lerna/create": "8.2.4", "@npmcli/arborist": "7.5.4", "@npmcli/package-json": "5.2.0", "@npmcli/run-script": "8.1.0", "@nx/devkit": ">=17.1.2 < 21", "@octokit/plugin-enterprise-rest": "6.0.1", "@octokit/rest": "20.1.2", "aproba": "2.0.0", "byte-size": "8.1.1", "chalk": "4.1.0", "clone-deep": "4.0.1", "cmd-shim": "6.0.3", "color-support": "1.1.3", "columnify": "1.6.0", "console-control-strings": "^1.1.0", "conventional-changelog-angular": "7.0.0", "conventional-changelog-core": "5.0.1", "conventional-recommended-bump": "7.0.1", "cosmiconfig": "9.0.0", "dedent": "1.5.3", "envinfo": "7.13.0", "execa": "5.0.0", "fs-extra": "^11.2.0", "get-port": "5.1.1", "get-stream": "6.0.0", "git-url-parse": "14.0.0", "glob-parent": "6.0.2", "graceful-fs": "4.2.11", "has-unicode": "2.0.1", "import-local": "3.1.0", "ini": "^1.3.8", "init-package-json": "6.0.3", "inquirer": "^8.2.4", "is-ci": "3.0.1", "is-stream": "2.0.0", "jest-diff": ">=29.4.3 < 30", "js-yaml": "4.1.0", "libnpmaccess": "8.0.6", "libnpmpublish": "9.0.9", "load-json-file": "6.2.0", "make-dir": "4.0.0", "minimatch": "3.0.5", "multimatch": "5.0.0", "node-fetch": "2.6.7", "npm-package-arg": "11.0.2", "npm-packlist": "8.0.2", "npm-registry-fetch": "^17.1.0", "nx": ">=17.1.2 < 21", "p-map": "4.0.0", "p-map-series": "2.1.0", "p-pipe": "3.1.0", "p-queue": "6.6.2", "p-reduce": "2.1.0", "p-waterfall": "2.1.1", "pacote": "^18.0.6", "pify": "5.0.0", "read-cmd-shim": "4.0.0", "resolve-from": "5.0.0", "rimraf": "^4.4.1", "semver": "^7.3.8", "set-blocking": "^2.0.0", "signal-exit": "3.0.7", "slash": "3.0.0", "ssri": "^10.0.6", "string-width": "^4.2.3", "tar": "6.2.1", "temp-dir": "1.0.0", "through": "2.3.8", "tinyglobby": "0.2.12", "typescript": ">=3 < 6", "upath": "2.0.1", "uuid": "^10.0.0", "validate-npm-package-license": "3.0.4", "validate-npm-package-name": "5.0.1", "wide-align": "1.1.5", "write-file-atomic": "5.0.1", "write-pkg": "4.0.0", "yargs": "17.7.2", "yargs-parser": "21.1.1" }, "bin": { "lerna": "dist/cli.js" } }, "sha512-0gaVWDIVT7fLfprfwpYcQajb7dBJv3EGavjG7zvJ+TmGx3/wovl5GklnSwM2/WeE0Z2wrIz7ndWhBcDUHVjOcQ=="],
 

--- a/clients/playground/package.json
+++ b/clients/playground/package.json
@@ -31,6 +31,7 @@
     "@modelcontextprotocol/sdk": "^1.18.1",
     "@monaco-editor/react": "^4.7.0",
     "@pstdio/kas": "*",
+    "@pstdio/kas-tracing": "*",
     "@pstdio/opfs-hooks": "*",
     "@pstdio/opfs-utils": "*",
     "@pstdio/prompt-utils": "*",

--- a/clients/playground/src/components/ui/settings-modal.tsx
+++ b/clients/playground/src/components/ui/settings-modal.tsx
@@ -37,11 +37,12 @@ const TOOL_LABELS: Record<string, string> = {
   opfs_move_file: "Move file",
 };
 
-type SettingsSectionId = "kas" | "display" | "permissions" | "mcp" | "plugins";
+type SettingsSectionId = "kas" | "display" | "tracing" | "permissions" | "mcp" | "plugins";
 
 const SETTINGS_SECTIONS: Array<{ id: SettingsSectionId; label: string }> = [
   { id: "kas", label: "Kas" },
   { id: "display", label: "Display" },
+  { id: "tracing", label: "Tracing" },
   { id: "permissions", label: "Permissions" },
   { id: "mcp", label: "MCP" },
   { id: "plugins", label: "Plugins" },
@@ -71,6 +72,11 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
   const [selectedWallpaper, setSelectedWallpaper] = useState<string>("");
   const [wallpaperPreviews, setWallpaperPreviews] = useState<Record<string, string>>({});
   const [reactScanEnabled, setReactScanEnabled] = useState(false);
+  const [tracingEnabled, setTracingEnabled] = useState(false);
+  const [langsmithApiKey, setLangsmithApiKey] = useState<string>("");
+  const [langsmithProject, setLangsmithProject] = useState<string>("");
+  const [langsmithEndpoint, setLangsmithEndpoint] = useState<string>("");
+  const [showLangsmithKey, setShowLangsmithKey] = useState<boolean>(false);
   const pluginSettingsRef = useRef<PluginSettingsHandle>(null);
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
 
@@ -92,6 +98,10 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
 
     setSelectedWallpaper(settings.wallpaper ?? DEFAULT_WALLPAPER);
     setReactScanEnabled(settings.reactScanEnabled ?? false);
+    setTracingEnabled(settings.tracingEnabled ?? false);
+    setLangsmithApiKey(settings.langsmithApiKey ?? "");
+    setLangsmithProject(settings.langsmithProject ?? "");
+    setLangsmithEndpoint(settings.langsmithEndpoint ?? "");
 
     const storedServers = settings.mcpServers;
     const effectiveServers = storedServers ?? [];
@@ -315,6 +325,10 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
         theme,
         wallpaper: selectedWallpaper,
         reactScanEnabled,
+        tracingEnabled,
+        langsmithApiKey: langsmithApiKey || undefined,
+        langsmithProject: langsmithProject || undefined,
+        langsmithEndpoint: langsmithEndpoint || undefined,
       });
 
       setInitialTheme(theme);
@@ -604,6 +618,55 @@ export function SettingsModal(props: { isOpen: boolean; onClose: () => void }) {
                             );
                           })}
                         </SimpleGrid>
+                      </Field.Root>
+                    </VStack>
+                  </Box>
+                  <Box display={activeSection === "tracing" ? "block" : "none"}>
+                    <VStack align="stretch" gap="md">
+                      <Text fontSize="sm" color="fg.muted">
+                        Send LLM and tool runs to LangSmith for inspection. Your key stays on this device and traces are
+                        sent directly from the browser.
+                      </Text>
+                      <Field.Root>
+                        <Field.Label>Tracing</Field.Label>
+                        <Checkbox.Root
+                          checked={tracingEnabled}
+                          onCheckedChange={(event) => setTracingEnabled(!!event.checked)}
+                        >
+                          <Checkbox.HiddenInput />
+                          <Checkbox.Control />
+                          <Checkbox.Label>Enable LangSmith tracing</Checkbox.Label>
+                        </Checkbox.Root>
+                      </Field.Root>
+                      <Field.Root>
+                        <Field.Label>LangSmith API Key</Field.Label>
+                        <HStack>
+                          <Input
+                            type={showLangsmithKey ? "text" : "password"}
+                            placeholder="lsv2_..."
+                            value={langsmithApiKey}
+                            onChange={(e) => setLangsmithApiKey(e.target.value)}
+                          />
+                          <Button onClick={() => setShowLangsmithKey((v) => !v)}>
+                            {showLangsmithKey ? "Hide" : "Show"}
+                          </Button>
+                        </HStack>
+                      </Field.Root>
+                      <Field.Root>
+                        <Field.Label>Project (optional)</Field.Label>
+                        <Input
+                          placeholder="kaset"
+                          value={langsmithProject}
+                          onChange={(e) => setLangsmithProject(e.target.value)}
+                        />
+                      </Field.Root>
+                      <Field.Root>
+                        <Field.Label>Endpoint (optional)</Field.Label>
+                        <Input
+                          placeholder="https://api.smith.langchain.com (use https://eu.api.smith.langchain.com for the EU)"
+                          value={langsmithEndpoint}
+                          onChange={(e) => setLangsmithEndpoint(e.target.value)}
+                        />
                       </Field.Root>
                     </VStack>
                   </Box>

--- a/clients/playground/src/services/ai/sendMessage.ts
+++ b/clients/playground/src/services/ai/sendMessage.ts
@@ -2,6 +2,7 @@ import { createApprovalGate, createKasAgent, type Model, openaiModel } from "@ps
 import type { UIConversation } from "@pstdio/kas/kas-ui";
 import { decorateWithThought, toBaseMessages, toConversationUI, withClosedThoughts } from "@pstdio/kas/kas-ui";
 import { createOpfsTools, loadAgentInstructions } from "@pstdio/kas/opfs-tools";
+import { beginAgentRun, configureTracing, traceModel, traceTool } from "@pstdio/kas-tracing";
 import { safeAutoCommit } from "@pstdio/opfs-utils";
 import type { Tool } from "@pstdio/tiny-ai-tasks";
 import { ROOT } from "@/constant";
@@ -19,6 +20,13 @@ export async function* sendMessage(_conversationId: string, messages: UIConversa
   const apiKey = settings.apiKey;
   const baseUrl = settings.baseUrl;
   const modelId = settings.modelId ?? "gpt-5";
+
+  configureTracing({
+    enabled: !!settings.tracingEnabled,
+    apiKey: settings.langsmithApiKey,
+    project: settings.langsmithProject || "kaset",
+    endpoint: settings.langsmithEndpoint || undefined,
+  });
 
   const approvalGate = createApprovalGate({ approvalGatedTools, requestApproval });
 
@@ -44,17 +52,31 @@ export async function* sendMessage(_conversationId: string, messages: UIConversa
     });
   }
 
-  const agent = createKasAgent({ model, tools });
-
   const initialMessages = [...agentInstructions.messages, ...messages];
+  const baseMessages = toBaseMessages(initialMessages);
+
+  const traceHandle = beginAgentRun("kas-agent", { messages: baseMessages });
+
+  const tracedModelId = provider === "webllm" ? settings.webllmModelId || DEFAULT_WEBLLM_MODEL_ID : modelId;
+  const tracedModel = traceModel(model, { name: "llm", model: tracedModelId, provider, parent: traceHandle });
+  const tracedTools = tools.map((tool) => traceTool(tool, { parent: traceHandle }));
+
+  const agent = createKasAgent({ model: tracedModel, tools: tracedTools });
 
   const { messages: initialUIMessages, thought } = decorateWithThought(messages);
 
   yield initialUIMessages;
 
-  for await (const ui of toConversationUI(agent(toBaseMessages(initialMessages)))) {
-    const next = withClosedThoughts([...initialUIMessages, ...ui], thought);
-    yield next;
+  try {
+    for await (const ui of toConversationUI(agent(baseMessages))) {
+      const next = withClosedThoughts([...initialUIMessages, ...ui], thought);
+      yield next;
+    }
+
+    await traceHandle?.end({ status: "ok" });
+  } catch (err) {
+    await traceHandle?.error(err);
+    throw err;
   }
 
   await safeAutoCommit({

--- a/clients/playground/src/state/actions/saveWorkspaceSettings.ts
+++ b/clients/playground/src/state/actions/saveWorkspaceSettings.ts
@@ -17,6 +17,10 @@ export const saveWorkspaceSettings = (settings: WorkspaceSettings, actionName = 
       state.settings.theme = settings.theme ?? DEFAULT_THEME;
       state.settings.wallpaper = settings.wallpaper ?? DEFAULT_WALLPAPER;
       state.settings.reactScanEnabled = settings.reactScanEnabled ?? false;
+      state.settings.tracingEnabled = settings.tracingEnabled ?? false;
+      state.settings.langsmithApiKey = settings.langsmithApiKey || undefined;
+      state.settings.langsmithProject = settings.langsmithProject || undefined;
+      state.settings.langsmithEndpoint = settings.langsmithEndpoint || undefined;
     },
     false,
     actionName,

--- a/clients/playground/src/state/defaultState.ts
+++ b/clients/playground/src/state/defaultState.ts
@@ -19,5 +19,9 @@ export const DEFAULT_STATE: WorkspaceState = {
     theme: DEFAULT_THEME,
     wallpaper: DEFAULT_WALLPAPER,
     reactScanEnabled: false,
+    tracingEnabled: false,
+    langsmithApiKey: "",
+    langsmithProject: "",
+    langsmithEndpoint: "",
   },
 };

--- a/clients/playground/src/state/types.ts
+++ b/clients/playground/src/state/types.ts
@@ -74,6 +74,10 @@ export interface WorkspaceSettings {
   theme: ThemePreference;
   wallpaper: string;
   reactScanEnabled: boolean;
+  tracingEnabled: boolean;
+  langsmithApiKey?: string;
+  langsmithProject?: string;
+  langsmithEndpoint?: string;
 }
 
 export interface WorkspaceState {

--- a/packages/@pstdio/kas-tracing/README.md
+++ b/packages/@pstdio/kas-tracing/README.md
@@ -1,0 +1,56 @@
+# @pstdio/kas-tracing
+
+Browser-first [LangSmith](https://smith.langchain.com/) tracing for `@pstdio` AI agents.
+
+Wrap a `Model` or `Tool` from [`@pstdio/tiny-ai-tasks`](../tiny-ai-tasks) and stream nested runs to
+LangSmith — a root agent run with child LLM and tool spans — entirely from the browser with a
+user-provided API key. It uses the LangSmith `RunTree` API with explicit parent references (no
+`AsyncLocalStorage`), so nesting works client-side.
+
+When tracing is off, every wrapper is a zero-overhead passthrough.
+
+## Usage
+
+```ts
+import { beginAgentRun, configureTracing, traceModel, traceTool } from "@pstdio/kas-tracing";
+
+// Configure once per run from your settings (key stored browser-local).
+configureTracing({
+  enabled: settings.tracingEnabled,
+  apiKey: settings.langsmithApiKey,
+  project: "kaset",
+});
+
+// Start a root run, then wrap the model and tools under it.
+const run = beginAgentRun("kas-agent", { messages });
+const model = traceModel(openaiModel({ model: "gpt-5", apiKey }), {
+  model: "gpt-5",
+  provider: "openai",
+  parent: run,
+});
+const tools = baseTools.map((tool) => traceTool(tool, { parent: run }));
+
+try {
+  // ...drive the agent with `model` + `tools`...
+  await run?.end({ status: "ok" });
+} catch (err) {
+  await run?.error(err);
+  throw err;
+}
+```
+
+`beginAgentRun` returns `null` when tracing is disabled, and `traceModel` / `traceTool` return their
+argument unchanged, so the wiring above costs nothing when off.
+
+## API
+
+- `configureTracing({ enabled, apiKey?, project?, endpoint?, client? })` — set up (or tear down) tracing.
+  `client` is an injection seam for tests.
+- `isTracingEnabled()` — whether runs will be sent.
+- `beginAgentRun(name, inputs)` — start a root `chain` run; returns a handle with `end(outputs?)` /
+  `error(err)`, or `null` when disabled.
+- `traceModel(model, { name?, model?, provider?, parent? })` — wrap a `Model` as a child `llm` run
+  (records messages in, assistant + token usage out).
+- `traceTool(tool, { parent? })` — wrap a `Tool` as a child `tool` run.
+
+A failed trace never interrupts the agent: posting is fire-and-forget and all LangSmith calls are guarded.

--- a/packages/@pstdio/kas-tracing/package.json
+++ b/packages/@pstdio/kas-tracing/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@pstdio/kas-tracing",
+  "description": "Browser-first LangSmith tracing for @pstdio AI agents: wrap a Model or Tool and stream nested runs to LangSmith.",
+  "version": "0.0.0",
+  "author": "Pufflig AB",
+  "email": "support@prompt.studio",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pufflyai/kaset.git"
+  },
+  "scripts": {
+    "prepublishOnly": "bun run build",
+    "build": "tsc -b && vite build",
+    "lint": "biome lint src",
+    "test": "vitest run",
+    "visualize-bundle": "bunx vite-bundle-visualizer"
+  },
+  "keywords": [
+    "langsmith",
+    "tracing",
+    "observability",
+    "llm",
+    "ai"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pstdio/tiny-ai-tasks": "^0.2.1",
+    "langsmith": "^0.7.11"
+  },
+  "devDependencies": {
+    "@au-re/vite-plugin-externalize-deps": "^0.9.1",
+    "typescript": "^5.7.3",
+    "vite": "^7.1.0",
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/@pstdio/kas-tracing/src/beginAgentRun.test.ts
+++ b/packages/@pstdio/kas-tracing/src/beginAgentRun.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { beginAgentRun } from "./beginAgentRun";
+import { configureTracing } from "./client";
+import { clearParents } from "./parentStack";
+import { createRecordingClient } from "./test-utils";
+
+let recording: ReturnType<typeof createRecordingClient>;
+
+beforeEach(() => {
+  recording = createRecordingClient();
+  configureTracing({ enabled: true, client: recording.client });
+  clearParents();
+});
+
+describe("beginAgentRun", () => {
+  it("creates a chain root run with the given inputs", async () => {
+    const handle = beginAgentRun("kas-agent", { messages: [{ role: "user", content: "hi" }] });
+    await recording.flush();
+
+    const root = recording.byType("chain")[0];
+    expect(handle).not.toBeNull();
+    expect(root.name).toBe("kas-agent");
+    expect(root.inputs).toEqual({ messages: [{ role: "user", content: "hi" }] });
+  });
+
+  it("finalizes the root run on end with outputs", async () => {
+    const handle = beginAgentRun("kas-agent", { messages: [] });
+    await handle?.end({ status: "ok" });
+    await recording.flush();
+
+    const root = recording.byType("chain")[0];
+    expect(root.outputs).toEqual({ status: "ok" });
+    expect(root.ended).toBe(true);
+  });
+
+  it("records an error on the root run", async () => {
+    const handle = beginAgentRun("kas-agent", { messages: [] });
+    await handle?.error(new Error("run failed"));
+    await recording.flush();
+
+    expect(recording.byType("chain")[0].error).toContain("run failed");
+  });
+
+  it("returns null when tracing is disabled", () => {
+    configureTracing({ enabled: false });
+    expect(beginAgentRun("kas-agent", {})).toBeNull();
+  });
+});

--- a/packages/@pstdio/kas-tracing/src/beginAgentRun.ts
+++ b/packages/@pstdio/kas-tracing/src/beginAgentRun.ts
@@ -1,0 +1,43 @@
+import { RunTree } from "langsmith";
+import { getClient, getProject, isTracingEnabled } from "./client";
+import { noop, stringifyError } from "./internal";
+import { popParent, pushParent } from "./parentStack";
+
+export interface AgentRunHandle {
+  runTree: RunTree;
+  end: (outputs?: Record<string, unknown>) => Promise<void>;
+  error: (err: unknown) => Promise<void>;
+}
+
+// Start a root run for a whole agent invocation. Returns null when tracing is off,
+// so callers can `handle?.end(...)` with zero overhead in the disabled case.
+export function beginAgentRun(name: string, inputs: Record<string, unknown>): AgentRunHandle | null {
+  if (!isTracingEnabled()) return null;
+
+  const runTree = new RunTree({
+    name,
+    run_type: "chain",
+    inputs,
+    client: getClient(),
+    project_name: getProject(),
+    tracingEnabled: true,
+  });
+
+  pushParent(runTree);
+
+  // Fire-and-forget: a failed trace POST must never block or break the agent.
+  void runTree.postRun().catch(noop);
+
+  const finish = async (outputs?: Record<string, unknown>, err?: unknown) => {
+    popParent(runTree);
+
+    await runTree.end(outputs, err != null ? stringifyError(err) : undefined).catch(noop);
+    await runTree.patchRun().catch(noop);
+  };
+
+  return {
+    runTree,
+    end: (outputs) => finish(outputs),
+    error: (err) => finish(undefined, err),
+  };
+}

--- a/packages/@pstdio/kas-tracing/src/client.test.ts
+++ b/packages/@pstdio/kas-tracing/src/client.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { beginAgentRun } from "./beginAgentRun";
+import { configureTracing, isTracingEnabled } from "./client";
+import { clearParents } from "./parentStack";
+import { createRecordingClient, fakeModel, makeAssistant } from "./test-utils";
+import { traceModel } from "./traceModel";
+
+beforeEach(() => {
+  configureTracing({ enabled: false });
+  clearParents();
+});
+
+describe("configureTracing", () => {
+  it("is disabled by default", () => {
+    expect(isTracingEnabled()).toBe(false);
+  });
+
+  it("stays disabled when enabled but no key or client is provided", () => {
+    configureTracing({ enabled: true });
+    expect(isTracingEnabled()).toBe(false);
+  });
+
+  it("enables when an injected client is provided", () => {
+    const { client } = createRecordingClient();
+    configureTracing({ enabled: true, client });
+    expect(isTracingEnabled()).toBe(true);
+  });
+
+  it("can be turned back off", () => {
+    const { client } = createRecordingClient();
+    configureTracing({ enabled: true, client });
+    configureTracing({ enabled: false });
+    expect(isTracingEnabled()).toBe(false);
+  });
+});
+
+describe("disabled passthrough", () => {
+  it("beginAgentRun returns null", () => {
+    expect(beginAgentRun("kas-agent", { messages: [] })).toBeNull();
+  });
+
+  it("traceModel returns the original model reference", () => {
+    const model = fakeModel([], makeAssistant("done"));
+    expect(traceModel(model)).toBe(model);
+  });
+});

--- a/packages/@pstdio/kas-tracing/src/client.ts
+++ b/packages/@pstdio/kas-tracing/src/client.ts
@@ -1,0 +1,55 @@
+import { Client } from "langsmith";
+
+const DEFAULT_ENDPOINT = "https://api.smith.langchain.com";
+const DEFAULT_PROJECT = "kaset";
+
+export interface ConfigureTracingOptions {
+  enabled: boolean;
+  apiKey?: string;
+  project?: string;
+  endpoint?: string;
+  // Injection seam for tests; defaults to a real LangSmith client built from apiKey/endpoint.
+  client?: Client;
+}
+
+interface TracingState {
+  enabled: boolean;
+  client?: Client;
+  project: string;
+}
+
+let state: TracingState = { enabled: false, project: DEFAULT_PROJECT };
+
+export function configureTracing(opts: ConfigureTracingOptions) {
+  const client =
+    opts.client ??
+    (opts.apiKey
+      ? new Client({
+          apiKey: opts.apiKey,
+          apiUrl: opts.endpoint ?? DEFAULT_ENDPOINT,
+          // Post each run immediately instead of buffering into a batch that needs a flush.
+          autoBatchTracing: false,
+        })
+      : undefined);
+
+  // Tracing only turns on when explicitly enabled AND we have somewhere to send runs.
+  const enabled = Boolean(opts.enabled && client);
+
+  state = {
+    enabled,
+    client: enabled ? client : undefined,
+    project: opts.project || DEFAULT_PROJECT,
+  };
+}
+
+export function isTracingEnabled() {
+  return state.enabled && !!state.client;
+}
+
+export function getClient() {
+  return state.client;
+}
+
+export function getProject() {
+  return state.project;
+}

--- a/packages/@pstdio/kas-tracing/src/index.ts
+++ b/packages/@pstdio/kas-tracing/src/index.ts
@@ -1,0 +1,8 @@
+export { beginAgentRun } from "./beginAgentRun";
+export type { AgentRunHandle } from "./beginAgentRun";
+export { configureTracing, isTracingEnabled } from "./client";
+export type { ConfigureTracingOptions } from "./client";
+export { traceModel } from "./traceModel";
+export type { TraceModelMeta } from "./traceModel";
+export { traceTool } from "./traceTool";
+export type { TraceToolMeta } from "./traceTool";

--- a/packages/@pstdio/kas-tracing/src/internal.ts
+++ b/packages/@pstdio/kas-tracing/src/internal.ts
@@ -1,0 +1,27 @@
+import type { AssistantMessage, BaseMessage } from "@pstdio/tiny-ai-tasks";
+
+export const noop = () => {};
+
+export function stringifyError(err: unknown) {
+  if (err instanceof Error) return err.stack || err.message;
+  return String(err);
+}
+
+type ModelMessageInput = BaseMessage[] | { messages: BaseMessage[] };
+
+export function extractMessages(input: ModelMessageInput): BaseMessage[] {
+  return Array.isArray(input) ? input : input.messages;
+}
+
+// LangSmith reads token counts from `usage_metadata` on an llm run, using its own
+// field names. Map the OpenAI-style counts our AssistantMessage carries onto those.
+export function toUsageMetadata(usage: AssistantMessage["usage"]) {
+  if (!usage) return undefined;
+
+  const metadata: Record<string, number> = {};
+  if (usage.prompt_tokens != null) metadata.input_tokens = usage.prompt_tokens;
+  if (usage.completion_tokens != null) metadata.output_tokens = usage.completion_tokens;
+  if (usage.total_tokens != null) metadata.total_tokens = usage.total_tokens;
+
+  return Object.keys(metadata).length ? metadata : undefined;
+}

--- a/packages/@pstdio/kas-tracing/src/nesting.test.ts
+++ b/packages/@pstdio/kas-tracing/src/nesting.test.ts
@@ -1,0 +1,62 @@
+import type { BaseMessage } from "@pstdio/tiny-ai-tasks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { beginAgentRun } from "./beginAgentRun";
+import { configureTracing } from "./client";
+import { clearParents } from "./parentStack";
+import { createRecordingClient, fakeModel, makeAssistant } from "./test-utils";
+import { traceModel } from "./traceModel";
+
+const userMessages: BaseMessage[] = [{ role: "user", content: "hi" }];
+
+async function drain(model: ReturnType<typeof fakeModel>, input: unknown) {
+  const gen = model(input as any);
+  while (!(await gen.next()).done) {
+    /* exhaust */
+  }
+}
+
+let recording: ReturnType<typeof createRecordingClient>;
+
+beforeEach(() => {
+  recording = createRecordingClient();
+  configureTracing({ enabled: true, client: recording.client });
+  clearParents();
+});
+
+describe("nesting", () => {
+  it("attaches the llm child to the explicit parent agent run", async () => {
+    const handle = beginAgentRun("kas-agent", { messages: userMessages });
+    const traced = traceModel(fakeModel([], makeAssistant("answer")), { parent: handle });
+
+    await drain(traced, userMessages);
+    await recording.flush();
+
+    const llm = recording.byType("llm")[0];
+    expect(llm.parent_run_id).toBe(handle?.runTree.id);
+  });
+
+  it("falls back to the active run on the parent stack when no parent is passed", async () => {
+    const handle = beginAgentRun("kas-agent", { messages: userMessages });
+    const traced = traceModel(fakeModel([], makeAssistant("answer")));
+
+    await drain(traced, userMessages);
+    await recording.flush();
+
+    expect(recording.byType("llm")[0].parent_run_id).toBe(handle?.runTree.id);
+  });
+
+  it("keeps concurrent agent runs separate via explicit parents", async () => {
+    const h1 = beginAgentRun("agent-1", { messages: userMessages });
+    const h2 = beginAgentRun("agent-2", { messages: userMessages });
+
+    const m1 = traceModel(fakeModel([], makeAssistant("a1")), { parent: h1 });
+    const m2 = traceModel(fakeModel([], makeAssistant("a2")), { parent: h2 });
+
+    await Promise.all([drain(m1, userMessages), drain(m2, userMessages)]);
+    await recording.flush();
+
+    const llms = recording.byType("llm");
+    const parents = new Set(llms.map((r) => r.parent_run_id));
+    expect(parents).toEqual(new Set([h1?.runTree.id, h2?.runTree.id]));
+  });
+});

--- a/packages/@pstdio/kas-tracing/src/parentStack.ts
+++ b/packages/@pstdio/kas-tracing/src/parentStack.ts
@@ -1,0 +1,23 @@
+import type { RunTree } from "langsmith";
+
+// Fallback parent lookup for tracers invoked without an explicit parent handle.
+// JS is single-threaded and the agent loop awaits each LLM call in turn, so the
+// top of the stack is the active root while a run is in flight.
+const stack: RunTree[] = [];
+
+export function pushParent(run: RunTree) {
+  stack.push(run);
+}
+
+export function popParent(run: RunTree) {
+  const index = stack.lastIndexOf(run);
+  if (index >= 0) stack.splice(index, 1);
+}
+
+export function currentParent(): RunTree | undefined {
+  return stack[stack.length - 1];
+}
+
+export function clearParents() {
+  stack.length = 0;
+}

--- a/packages/@pstdio/kas-tracing/src/test-utils.ts
+++ b/packages/@pstdio/kas-tracing/src/test-utils.ts
@@ -1,0 +1,92 @@
+import type { Client } from "langsmith";
+import type { AssistantMessage, Model } from "@pstdio/tiny-ai-tasks";
+
+export interface RecordedRun {
+  id: string;
+  name: string;
+  run_type: string;
+  parent_run_id?: string;
+  inputs?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  error?: string;
+  ended: boolean;
+}
+
+// A minimal stand-in for the LangSmith Client that records the create/update calls
+// RunTree.postRun()/patchRun() make, so assertions stay offline and deterministic.
+export function createRecordingClient() {
+  const runs = new Map<string, RecordedRun>();
+  const order: string[] = [];
+
+  const client = {
+    createRun: async (run: any) => {
+      runs.set(run.id, {
+        id: run.id,
+        name: run.name,
+        run_type: run.run_type,
+        parent_run_id: run.parent_run_id,
+        inputs: run.inputs,
+        extra: run.extra,
+        ended: false,
+      });
+      order.push(run.id);
+    },
+    updateRun: async (id: string, update: any) => {
+      const rec = runs.get(id);
+      if (!rec) return;
+      if (update.outputs !== undefined) rec.outputs = update.outputs;
+      if (update.error !== undefined) rec.error = update.error;
+      if (update.end_time !== undefined) rec.ended = true;
+    },
+    batchIngestRuns: async () => {},
+    multipartIngestRuns: async () => {},
+  };
+
+  const list = () => order.map((id) => runs.get(id) as RecordedRun);
+
+  return {
+    client: client as unknown as Client,
+    list,
+    byType: (type: string) => list().filter((r) => r.run_type === type),
+    // Let fire-and-forget postRun()/patchRun() microtasks settle before asserting.
+    flush: () => new Promise((resolve) => setTimeout(resolve, 0)),
+  };
+}
+
+export function makeAssistant(content: string, usage?: AssistantMessage["usage"]): AssistantMessage {
+  return { role: "assistant", content, ...(usage ? { usage } : {}) };
+}
+
+// A fake Model that yields the given snapshots as [message, snapshot, ...] tuples and
+// returns the final message, matching the real Task streaming contract.
+export function fakeModel(snapshots: AssistantMessage[], final: AssistantMessage): Model {
+  const fn = async function* (_input: unknown) {
+    for (const snapshot of snapshots) {
+      yield [snapshot, undefined, undefined];
+    }
+    return final;
+  };
+
+  return attachTaskMethods(fn, final);
+}
+
+export function throwingModel(snapshots: AssistantMessage[], err: Error): Model {
+  const fn = async function* (_input: unknown) {
+    for (const snapshot of snapshots) {
+      yield [snapshot, undefined, undefined];
+    }
+    throw err;
+  };
+
+  return attachTaskMethods(fn, snapshots[snapshots.length - 1]);
+}
+
+function attachTaskMethods(fn: (input: unknown) => AsyncGenerator<unknown[], unknown>, final: unknown) {
+  return Object.assign(fn, {
+    invoke: async () => final,
+    resume: async function* () {
+      return final;
+    },
+  }) as unknown as Model;
+}

--- a/packages/@pstdio/kas-tracing/src/traceModel.test.ts
+++ b/packages/@pstdio/kas-tracing/src/traceModel.test.ts
@@ -1,0 +1,92 @@
+import type { BaseMessage } from "@pstdio/tiny-ai-tasks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { beginAgentRun } from "./beginAgentRun";
+import { configureTracing } from "./client";
+import { clearParents } from "./parentStack";
+import { createRecordingClient, fakeModel, makeAssistant, throwingModel } from "./test-utils";
+import { traceModel } from "./traceModel";
+
+const userMessages: BaseMessage[] = [{ role: "user", content: "hi" }];
+
+async function drain(model: ReturnType<typeof fakeModel>, input: unknown) {
+  const snapshots: unknown[] = [];
+  const gen = model(input as any);
+
+  while (true) {
+    const next = await gen.next();
+    if (next.done) return { snapshots, returned: next.value };
+    snapshots.push(next.value);
+  }
+}
+
+let recording: ReturnType<typeof createRecordingClient>;
+
+beforeEach(() => {
+  recording = createRecordingClient();
+  configureTracing({ enabled: true, client: recording.client });
+  clearParents();
+});
+
+describe("traceModel streaming contract", () => {
+  it("yields the same snapshots and returns the same final message", async () => {
+    const snapA = makeAssistant("par");
+    const snapB = makeAssistant("partial");
+    const final = makeAssistant("partial answer", { total_tokens: 3 });
+
+    const handle = beginAgentRun("kas-agent", { messages: userMessages });
+    const traced = traceModel(fakeModel([snapA, snapB], final), { parent: handle });
+
+    const { snapshots, returned } = await drain(traced, userMessages);
+
+    expect(snapshots).toEqual([
+      [snapA, undefined, undefined],
+      [snapB, undefined, undefined],
+    ]);
+    expect(returned).toBe(final);
+  });
+});
+
+describe("traceModel run recording", () => {
+  it("records an llm run with messages in and assistant + usage out", async () => {
+    const final = makeAssistant("answer", { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
+
+    const handle = beginAgentRun("kas-agent", { messages: userMessages });
+    const traced = traceModel(fakeModel([], final), { parent: handle, model: "gpt-5", provider: "openai" });
+
+    await drain(traced, userMessages);
+    await recording.flush();
+
+    const llm = recording.byType("llm")[0];
+    expect(llm.run_type).toBe("llm");
+    expect(llm.inputs).toEqual({ messages: userMessages });
+    expect((llm.outputs as any).messages).toEqual([final]);
+    expect((llm.outputs as any).usage_metadata).toEqual({ input_tokens: 10, output_tokens: 5, total_tokens: 15 });
+    expect((llm.extra as any).metadata.ls_model_name).toBe("gpt-5");
+    expect((llm.extra as any).metadata.ls_provider).toBe("openai");
+    expect(llm.ended).toBe(true);
+  });
+
+  it("accepts the object input form { messages, tools, sessionId }", async () => {
+    const final = makeAssistant("answer");
+    const handle = beginAgentRun("kas-agent", { messages: userMessages });
+    const traced = traceModel(fakeModel([], final), { parent: handle });
+
+    await drain(traced, { messages: userMessages, sessionId: "s1" });
+    await recording.flush();
+
+    expect(recording.byType("llm")[0].inputs).toEqual({ messages: userMessages });
+  });
+
+  it("records an error and rethrows when the inner model throws", async () => {
+    const boom = new Error("model exploded");
+    const handle = beginAgentRun("kas-agent", { messages: userMessages });
+    const traced = traceModel(throwingModel([makeAssistant("par")], boom), { parent: handle });
+
+    await expect(drain(traced, userMessages)).rejects.toThrow("model exploded");
+    await recording.flush();
+
+    const llm = recording.byType("llm")[0];
+    expect(llm.error).toContain("model exploded");
+    expect(llm.ended).toBe(true);
+  });
+});

--- a/packages/@pstdio/kas-tracing/src/traceModel.ts
+++ b/packages/@pstdio/kas-tracing/src/traceModel.ts
@@ -1,0 +1,79 @@
+import type { AssistantMessage, Model } from "@pstdio/tiny-ai-tasks";
+import type { AgentRunHandle } from "./beginAgentRun";
+import { isTracingEnabled } from "./client";
+import { extractMessages, noop, stringifyError, toUsageMetadata } from "./internal";
+import { currentParent } from "./parentStack";
+
+export interface TraceModelMeta {
+  name?: string;
+  model?: string;
+  provider?: string;
+  parent?: AgentRunHandle | null;
+}
+
+type ModelInput = Parameters<Model>[0];
+
+// Wrap a Model so each invocation becomes a child "llm" run under the active agent run.
+// Returns the model unchanged when tracing is off, so wrapping is free in that case.
+export function traceModel(model: Model, meta: TraceModelMeta = {}): Model {
+  if (!isTracingEnabled()) return model;
+
+  const traced = async function* (input: ModelInput) {
+    const parent = meta.parent?.runTree ?? currentParent();
+    if (!parent) {
+      return yield* model(input);
+    }
+
+    const run = parent.createChild({
+      name: meta.name ?? "llm",
+      run_type: "llm",
+      inputs: { messages: extractMessages(input) },
+      extra: { metadata: pruneMetadata(meta) },
+    });
+
+    void run.postRun().catch(noop);
+
+    let final: AssistantMessage | undefined;
+
+    try {
+      const inner = model(input);
+
+      // Re-yield every [message, snapshot, ...] tuple unchanged to preserve streaming.
+      while (true) {
+        const next = await inner.next();
+        if (next.done) {
+          final = next.value ?? final;
+          break;
+        }
+
+        final = next.value[0] ?? final;
+        yield next.value;
+      }
+    } catch (err) {
+      await run.end(undefined, stringifyError(err)).catch(noop);
+      await run.patchRun().catch(noop);
+      throw err;
+    }
+
+    const usage_metadata = toUsageMetadata(final?.usage);
+
+    await run.end({ messages: final ? [final] : [], ...(usage_metadata ? { usage_metadata } : {}) }).catch(noop);
+    await run.patchRun().catch(noop);
+
+    return final as AssistantMessage;
+  };
+
+  // The agent loop only calls + iterates the model; invoke/resume are part of the
+  // Model contract but unused here, so delegate them to the original.
+  return Object.assign(traced, {
+    invoke: model.invoke.bind(model),
+    resume: model.resume.bind(model),
+  }) as unknown as Model;
+}
+
+function pruneMetadata(meta: TraceModelMeta) {
+  const metadata: Record<string, string> = {};
+  if (meta.provider) metadata.ls_provider = meta.provider;
+  if (meta.model) metadata.ls_model_name = meta.model;
+  return metadata;
+}

--- a/packages/@pstdio/kas-tracing/src/traceTool.test.ts
+++ b/packages/@pstdio/kas-tracing/src/traceTool.test.ts
@@ -1,0 +1,48 @@
+import { Tool } from "@pstdio/tiny-ai-tasks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { beginAgentRun } from "./beginAgentRun";
+import { configureTracing } from "./client";
+import { clearParents } from "./parentStack";
+import { createRecordingClient } from "./test-utils";
+import { traceTool } from "./traceTool";
+
+const echoTool = Tool(async (params: { value: string }) => ({ echoed: params.value }), {
+  name: "echo",
+  description: "echoes its input",
+});
+
+let recording: ReturnType<typeof createRecordingClient>;
+
+beforeEach(() => {
+  recording = createRecordingClient();
+  configureTracing({ enabled: true, client: recording.client });
+  clearParents();
+});
+
+describe("traceTool", () => {
+  it("returns the original tool when tracing is disabled", () => {
+    configureTracing({ enabled: false });
+    expect(traceTool(echoTool)).toBe(echoTool);
+  });
+
+  it("preserves the tool definition so dispatch by name still works", () => {
+    const handle = beginAgentRun("kas-agent", {});
+    expect(traceTool(echoTool, { parent: handle }).definition).toBe(echoTool.definition);
+  });
+
+  it("records a tool run with inputs and outputs and returns the real result", async () => {
+    const handle = beginAgentRun("kas-agent", {});
+    const traced = traceTool(echoTool, { parent: handle });
+
+    const result = await traced.run({ value: "hello" }, {});
+    await recording.flush();
+
+    expect(result).toEqual({ echoed: "hello" });
+
+    const toolRun = recording.byType("tool")[0];
+    expect(toolRun.name).toBe("echo");
+    expect(toolRun.inputs).toEqual({ value: "hello" });
+    expect((toolRun.outputs as any).output).toEqual({ echoed: "hello" });
+    expect(toolRun.ended).toBe(true);
+  });
+});

--- a/packages/@pstdio/kas-tracing/src/traceTool.ts
+++ b/packages/@pstdio/kas-tracing/src/traceTool.ts
@@ -1,0 +1,53 @@
+import type { Tool } from "@pstdio/tiny-ai-tasks";
+import type { AgentRunHandle } from "./beginAgentRun";
+import { isTracingEnabled } from "./client";
+import { noop, stringifyError } from "./internal";
+import { currentParent } from "./parentStack";
+
+export interface TraceToolMeta {
+  parent?: AgentRunHandle | null;
+}
+
+// Wrap a Tool so each call becomes a child "tool" run. Preserves `definition` so the
+// agent's tool dispatch (which matches by definition.name) keeps working.
+export function traceTool<P, R>(tool: Tool<P, R>, meta: TraceToolMeta = {}): Tool<P, R> {
+  if (!isTracingEnabled()) return tool;
+
+  return {
+    definition: tool.definition,
+    run: async (params, config) => {
+      const parent = meta.parent?.runTree ?? currentParent();
+      if (!parent) return tool.run(params, config);
+
+      const run = parent.createChild({
+        name: tool.definition.name,
+        run_type: "tool",
+        inputs: toInputs(params),
+      });
+
+      void run.postRun().catch(noop);
+
+      try {
+        const result = await tool.run(params, config);
+
+        await run.end({ output: result }).catch(noop);
+        await run.patchRun().catch(noop);
+
+        return result;
+      } catch (err) {
+        await run.end(undefined, stringifyError(err)).catch(noop);
+        await run.patchRun().catch(noop);
+
+        throw err;
+      }
+    },
+  };
+}
+
+function toInputs(params: unknown): Record<string, unknown> {
+  if (params && typeof params === "object" && !Array.isArray(params)) {
+    return params as Record<string, unknown>;
+  }
+
+  return { input: params };
+}

--- a/packages/@pstdio/kas-tracing/tsconfig.json
+++ b/packages/@pstdio/kas-tracing/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src", "./index.ts"]
+}

--- a/packages/@pstdio/kas-tracing/vite.config.ts
+++ b/packages/@pstdio/kas-tracing/vite.config.ts
@@ -1,0 +1,23 @@
+import { externalizeDeps } from "@au-re/vite-plugin-externalize-deps";
+import path from "path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, "src/index.ts"),
+      name: "kas-tracing",
+      fileName: () => `index.js`,
+      formats: ["es"],
+    },
+    sourcemap: true,
+    emptyOutDir: true,
+  },
+  plugins: [
+    dts(),
+    externalizeDeps({
+      include: ["langsmith"],
+    }),
+  ],
+});


### PR DESCRIPTION
## What

Adds browser-first **LangSmith tracing** for the kas agent, with an on/off toggle and a bring-your-own key stored browser-local (same trust model as the OpenAI key).

New package **`@pstdio/kas-tracing`** wraps the `Model`/`Tool` abstractions from `@pstdio/tiny-ai-tasks` and emits a nested trace per message: a root `kas-agent` run with child `llm` (messages + token usage) and `tool` runs.

## Why

The playground runs its LLM agent fully client-side (OpenAI-compatible + in-browser WebLLM) and had **no observability** — no way to see prompts, responses, token usage, or tool calls. This adds that, without a backend.

## How it works

- Uses LangSmith's `RunTree` API with **explicit parent references** (not `traceable`/`AsyncLocalStorage`, which is unreliable in browsers), so run nesting works client-side.
- The root run is opened in `sendMessage` and the parent handle is passed explicitly into `traceModel`/`traceTool`, so attribution stays correct even across concurrent runs.
- Posting is fire-and-forget and every LangSmith call is guarded — **a failed trace never breaks the agent or interrupts streaming**.
- When the toggle is off, `beginAgentRun` returns `null` and the wrappers return their argument unchanged (zero overhead).
- CORS on the LangSmith ingestion endpoint is open for browser-direct POSTs (verified for both US and EU regions).

## Public API

- `configureTracing({ enabled, apiKey?, project?, endpoint?, client? })`
- `isTracingEnabled()`
- `beginAgentRun(name, inputs)` → handle with `end(outputs?)` / `error(err)`, or `null` when off
- `traceModel(model, { name?, model?, provider?, parent? })`
- `traceTool(tool, { parent? })`

## Playground changes

- New **Tracing** settings section: enable checkbox, masked LangSmith API key (show/hide), project, and **endpoint** (US default, with EU `https://eu.api.smith.langchain.com` supported).
- Settings persisted via the existing Zustand store; wired into `sendMessage.ts`.

## Testing

- **20 unit tests** in the new package (offline, injected recording client): passthrough-when-disabled, streaming-contract preservation, llm run + token-usage mapping, error path, root run, tool run, parent nesting, concurrent-run isolation.
- Repo gate green: `format`, `lint` (13 projects), `build` (14 projects — playground bundles `langsmith` with no Node-only break), `test` (11 projects).
- **Verified end-to-end in a real browser** (Playwright): sending a message produced `POST`/`PATCH` to `eu.api.smith.langchain.com/runs` → `202`, a root + nested `llm` run, with a successful model reply.

## Scope notes

- Pre-existing unrelated worktree changes (`tiny-ui-bundler`, `tiny-ui`, `wasm-url`, `playground/vite.config.ts`) are intentionally **not** included.
- Out of scope: flush-on-`pagehide` — runs are posted immediately (`autoBatchTracing: false`), so a tab close mid-run just leaves that one run un-finalized in LangSmith.