### PR TITLE
Pin esbuild wasm to installed version; shim DRAGGABLE_DEBUG in playground

### DIFF
--- a/.changeset/esbuild-wasm-version-pin.md
+++ b/.changeset/esbuild-wasm-version-pin.md
@@ -1,0 +1,6 @@
+---
+"@pstdio/tiny-ui-bundler": patch
+"@pstdio/tiny-ui": patch
+---
+
+Pin the esbuild wasm binary to the installed `esbuild-wasm` host version. `tiny-ui-bundler` now exports `DEFAULT_ESBUILD_WASM_URL`, derived from the installed version, and `tiny-ui`'s provider uses it instead of a hardcoded URL — preventing esbuild's "Host version does not match binary version" error when the host and binary drift.

--- a/clients/playground/vite.config.ts
+++ b/clients/playground/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [react(), svgr()],
     base: env.VITE_BASE_URL || "/",
+    // react-rnd's react-draggable reads process.env.DRAGGABLE_DEBUG, which is undefined in the browser.
+    define: {
+      "process.env.DRAGGABLE_DEBUG": "undefined",
+    },
     build: {
       assetsInlineLimit: 0,
     },

--- a/packages/@pstdio/tiny-ui-bundler/src/esbuild/wasm-url.test.ts
+++ b/packages/@pstdio/tiny-ui-bundler/src/esbuild/wasm-url.test.ts
@@ -1,0 +1,11 @@
+import { version } from "esbuild-wasm";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_ESBUILD_WASM_URL } from "./wasm-url";
+
+describe("DEFAULT_ESBUILD_WASM_URL", () => {
+  // Guards against esbuild's "Host version does not match binary version" error:
+  // the wasm binary must be pinned to the installed esbuild host version.
+  it("pins the wasm binary to the installed esbuild host version", () => {
+    expect(DEFAULT_ESBUILD_WASM_URL).toBe(`https://unpkg.com/esbuild-wasm@${version}/esbuild.wasm`);
+  });
+});

--- a/packages/@pstdio/tiny-ui-bundler/src/esbuild/wasm-url.ts
+++ b/packages/@pstdio/tiny-ui-bundler/src/esbuild/wasm-url.ts
@@ -1,0 +1,5 @@
+import { version } from "esbuild-wasm";
+
+// Pin the wasm binary to the installed esbuild host version so the two never drift.
+// A mismatch makes esbuild.initialize throw "Host version ... does not match binary version ...".
+export const DEFAULT_ESBUILD_WASM_URL = `https://unpkg.com/esbuild-wasm@${version}/esbuild.wasm`;

--- a/packages/@pstdio/tiny-ui-bundler/src/index.ts
+++ b/packages/@pstdio/tiny-ui-bundler/src/index.ts
@@ -20,6 +20,7 @@ export {
   updateSource,
 } from "./core/sources";
 export { compile } from "./esbuild/compile";
+export { DEFAULT_ESBUILD_WASM_URL } from "./esbuild/wasm-url";
 export { ensureVirtualFetchFallback, isServiceWorkerControlled } from "./runtime/fetch-fallback";
 export { type InlineStyleEntry, type PreparedRuntimeAssets, prepareRuntimeAssets } from "./runtime/prepare-runtime";
 export type { BuildWithEsbuildOptions, CompileResult } from "./types";

--- a/packages/@pstdio/tiny-ui/src/react/tiny-ui-provider.tsx
+++ b/packages/@pstdio/tiny-ui/src/react/tiny-ui-provider.tsx
@@ -1,10 +1,8 @@
-import { compile as bundleCompile, type CompileResult } from "@pstdio/tiny-ui-bundler";
+import { type CompileResult, compile as bundleCompile, DEFAULT_ESBUILD_WASM_URL } from "@pstdio/tiny-ui-bundler";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo } from "react";
 import { type SetupTinyUIOptions, setupTinyUI } from "../setupTinyUI";
 import type { TinyUIStatus } from "../types";
 import { useServiceWorkerStatus } from "./useServiceWorkerStatus";
-
-const DEFAULT_ESBUILD_WASM_URL = "https://unpkg.com/esbuild-wasm@0.25.11/esbuild.wasm";
 
 interface TinyUiProviderProps extends SetupTinyUIOptions {
   children: ReactNode;


### PR DESCRIPTION
## What

Two small browser-build fixes that were sitting in the worktree.

### 1. Pin the esbuild wasm binary to the installed host version
`@pstdio/tiny-ui-bundler` now exports `DEFAULT_ESBUILD_WASM_URL`, derived from the installed `esbuild-wasm` `version`:

```ts
export const DEFAULT_ESBUILD_WASM_URL = `https://unpkg.com/esbuild-wasm@${version}/esbuild.wasm`;
```

`@pstdio/tiny-ui`'s provider now imports this instead of a hardcoded `…@0.25.11/esbuild.wasm`. When the host and binary versions drift, `esbuild.initialize` throws `Host version "X" does not match binary version "Y"`; deriving the URL from the installed version keeps them in lockstep. Includes a regression test.

### 2. Shim `process.env.DRAGGABLE_DEBUG` in the playground
`react-rnd`'s `react-draggable` reads `process.env.DRAGGABLE_DEBUG`, which is undefined in the browser. The playground `vite.config.ts` now defines it as `undefined`:

```ts
define: { "process.env.DRAGGABLE_DEBUG": "undefined" },
```

## Testing

- `lint` (12 projects), `build` (13 projects), `test` (10 projects) all green.
- New regression test asserts `DEFAULT_ESBUILD_WASM_URL` tracks the installed `esbuild-wasm` version.

## Notes

- Independent of #226 (LangSmith tracing) — branched from `main`, no overlap.
- Changeset: `@pstdio/tiny-ui-bundler` + `@pstdio/tiny-ui` patch.